### PR TITLE
fix: add skip_s3_checksum for R2 compatibility

### DIFF
--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -17,6 +17,7 @@ terraform {
     skip_credentials_validation = true
     skip_region_validation      = true
     skip_requesting_account_id  = true
+    skip_s3_checksum            = true
     use_path_style              = true
   }
 }


### PR DESCRIPTION
## Problem
Terraform S3 backend failed to save state to Cloudflare R2 with:
```
SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided.
```

## Root Cause
Cloudflare R2 doesn't support S3 checksums that Terraform uses by default.

## Solution
Added `skip_s3_checksum = true` to backend.tf.

## Verification
- ✅ Local terraform apply now successfully saves state to R2
- ✅ terraform state list shows all resources
- ✅ k3s cluster running on VPS (truealpha-k3s Ready)