### PR TITLE
fix: terraform fmt only checks phases/ dir

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Terraform fmt
         working-directory: terraform
-        run: terraform fmt -check
+        run: terraform fmt -check -recursive -diff phases/
 
       - name: Terraform init
         working-directory: terraform


### PR DESCRIPTION
Skip fmt check on dynamically generated terraform.tfvars