### PR TITLE
fix: handle missing kubeconfig in providers

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -30,14 +30,14 @@ provider "aws" {
   # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for R2 backend
 }
 
-# Helm provider depends on kubeconfig from k3s provisioning
+# Helm provider - only configure if kubeconfig exists (after k3s deployment)
 provider "helm" {
   kubernetes {
-    config_path = local.kubeconfig_path
+    config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
   }
 }
 
-# Kubernetes provider for namespace creation
+# Kubernetes provider - only configure if kubeconfig exists (after k3s deployment)
 provider "kubernetes" {
-  config_path = local.kubeconfig_path
+  config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
 }


### PR DESCRIPTION
Fixes terraform plan failing before k3s deployment.

- providers.tf: use fileexists() to conditionally set config_path  
- 1_3_dashboard.tf: replace kubernetes_manifest with kubernetes_namespace