### PR TITLE
fix: postgresql image tag

### DIFF
--- a/terraform/phases/1_1_postgresql.tf
+++ b/terraform/phases/1_1_postgresql.tf
@@ -18,6 +18,9 @@ resource "helm_release" "postgresql" {
 
   values = [
     yamlencode({
+      image = {
+        tag = "16.4.0-debian-12-r23" # Explicit tag to avoid image pull errors
+      }
       auth = {
         username = "infisical"
         password = var.infisical_postgres_password


### PR DESCRIPTION
Fixes ImagePullBackOff error - image 16.0.0-debian-11-r3 doesn't exist