### PR TITLE
fix(infisical): upgrade stack to v1.7.2/v0.154.0

### DIFF
--- a/terraform/phases/0_1_infisical.tf
+++ b/terraform/phases/0_1_infisical.tf
@@ -39,7 +39,7 @@ resource "helm_release" "infisical" {
   name             = "infisical"
   namespace        = var.namespaces["iac"]
   repository       = "https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/"
-  chart            = "infisical"
+  chart            = "infisical-standalone"
   version          = var.infisical_chart_version
   create_namespace = false
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -116,13 +116,13 @@ variable "neo4j_storage" {
 variable "infisical_chart_version" {
   description = "Helm chart version for Infisical"
   type        = string
-  default     = "0.4.2"
+  default     = "1.7.2"
 }
 
 variable "infisical_image_tag" {
   description = "Docker image tag for Infisical backend"
   type        = string
-  default     = "1.17.0"
+  default     = "v0.154.0"
 }
 
 variable "infisical_api_token" {


### PR DESCRIPTION
Upgrades Infisical chart to modern infisical-standalone 1.7.2 and bumps image to v0.154.0. Removes legacy MongoDB dependency and fixes image pull errors.