### PR TITLE
fix(infisical): use kubernetes_secret for env vars

### DIFF
--- a/terraform/phases/0_1_infisical.tf
+++ b/terraform/phases/0_1_infisical.tf
@@ -65,36 +65,6 @@ resource "helm_release" "infisical" {
         }
       }
 
-      backendEnvironmentVariables = {
-        # Database - using external PostgreSQL
-        DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.${var.namespaces["iac"]}.svc.cluster.local:5432/infisical"
-
-        # Encryption keys
-        ENCRYPTION_KEY           = random_id.infisical_encryption_key.hex
-        JWT_SIGNUP_SECRET        = random_id.infisical_jwt_signup_secret.hex
-        JWT_REFRESH_SECRET       = random_id.infisical_jwt_refresh_secret.hex
-        JWT_AUTH_SECRET          = random_id.infisical_jwt_auth_secret.hex
-        JWT_SERVICE_SECRET       = random_id.infisical_jwt_service_secret.hex
-        JWT_MFA_SECRET           = random_id.infisical_jwt_mfa_secret.hex
-        JWT_PROVIDER_AUTH_SECRET = random_id.infisical_jwt_provider_secret.hex
-
-        # Site configuration
-        SITE_URL           = "http://infisical.local"
-        INVITE_ONLY_SIGNUP = false
-
-        # SMTP configuration (using mailhog for dev)
-        SMTP_HOST         = "mailhog"
-        SMTP_PORT         = 1025
-        SMTP_SECURE       = false
-        SMTP_FROM_NAME    = "Infisical"
-        SMTP_FROM_ADDRESS = "noreply@infisical.local"
-        SMTP_USERNAME     = "noreply@infisical.local"
-        SMTP_PASSWORD     = ""
-
-        # Redis (embedded)
-        REDIS_URL = "redis://:@infisical-redis-master:6379"
-      }
-
       # Disable embedded PostgreSQL (using external)
       postgresql = {
         enabled = false
@@ -139,8 +109,48 @@ resource "helm_release" "infisical" {
   ]
 
   depends_on = [
-    helm_release.postgresql
+    helm_release.postgresql,
+    kubernetes_secret.infisical_secrets
   ]
+}
+
+resource "kubernetes_secret" "infisical_secrets" {
+  metadata {
+    name      = "infisical-secrets"
+    namespace = var.namespaces["iac"]
+  }
+
+  data = {
+    # Database - using external PostgreSQL
+    DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.${var.namespaces["iac"]}.svc.cluster.local:5432/infisical"
+
+    # Encryption keys
+    ENCRYPTION_KEY           = random_id.infisical_encryption_key.hex
+    AUTH_SECRET              = random_id.infisical_jwt_auth_secret.hex
+    JWT_SIGNUP_SECRET        = random_id.infisical_jwt_signup_secret.hex
+    JWT_REFRESH_SECRET       = random_id.infisical_jwt_refresh_secret.hex
+    JWT_AUTH_SECRET          = random_id.infisical_jwt_auth_secret.hex
+    JWT_SERVICE_SECRET       = random_id.infisical_jwt_service_secret.hex
+    JWT_MFA_SECRET           = random_id.infisical_jwt_mfa_secret.hex
+    JWT_PROVIDER_AUTH_SECRET = random_id.infisical_jwt_provider_secret.hex
+
+    # Site configuration
+    SITE_URL           = "http://infisical.local"
+    INVITE_ONLY_SIGNUP = "false"
+
+    # SMTP configuration
+    SMTP_HOST         = "mailhog"
+    SMTP_PORT         = "1025"
+    SMTP_SECURE       = "false"
+    SMTP_FROM_NAME    = "Infisical"
+    SMTP_FROM_ADDRESS = "noreply@infisical.local"
+    SMTP_USERNAME     = "noreply@infisical.local"
+    SMTP_PASSWORD     = ""
+
+    # Redis (embedded)
+    REDIS_URL = "redis://:@infisical-redis-master:6379"
+  }
+
 }
 
 output "infisical_endpoint" {


### PR DESCRIPTION
Refactors Infisical config to use a Terraform-managed infisical-secrets resource, resolving secret not found errors.