### PR TITLE
fix(terraform): migrate state and update context

### DIFF
--- a/0.check_now.md
+++ b/0.check_now.md
@@ -1,1 +1,26 @@
-docs/change_log/2025-12-06.checklist_merge.md
+# 0.check_now — Current Sprint Context
+
+**Status**: Active
+**Focus**: CI Standardization & Workflow Refinement
+
+## 1. Context: What are we doing?
+We are refactoring the infrastructure to be cleaner, more standard, and "Dry".
+
+### Recent accomplishments:
+1.  **SSOT Refactor**: Promoted `terraform/0.common` to `terraform/` root. Restructured layers (1.nodep, 2.env, etc.).
+2.  **CI Standardization**: Solved "Two YAMLs Problem" by creating `.github/actions/terraform-setup/` (Composite Action). Plan and Apply now share identical setup logic.
+
+## 2. Current Task: Workflow Refinement
+User requested a better mechanism for tracking "Current Context".
+- **Old Way**: Symlink to specific changelog.
+- **New Way**: This file (`0.check_now.md`) is the **Living Context**. It accumulates context, decisions, and attempts.
+- **Lifecycle**: When this "Sprint" or "Topic" is done, this file is moved to `docs/change_log/YYYY-MM-DD.topic.md` and a new `0.check_now.md` is created.
+
+## 3. Next Steps
+- [ ] Verify CI stability after standardization. (Done - PR #34 Merged)
+- [ ] Refactor `0.check_now.md` mechanism (This task).
+- [ ] Continue with `3.computing` (Kubero) implementation.
+
+## 4. Notes / Attempts
+- *Attempt 1*: Tried to fix CI via just editing YAMLs. Failed because `fmt` and `ssh` setup drifted.
+- *Attempt 2*: Implemented Composite Action. Success. (See PR #34).

--- a/terraform/moved.tf
+++ b/terraform/moved.tf
@@ -1,0 +1,105 @@
+# Migration from monolithic 'module.phases' to layered architecture (1.nodep, 2.env_and_networking, 3.computing)
+
+# L1: Bootstrap (K3s)
+moved {
+  from = module.phases.null_resource.k3s_server
+  to   = module.nodep.null_resource.k3s_server
+}
+
+moved {
+  from = module.phases.null_resource.kubeconfig
+  to   = module.nodep.null_resource.kubeconfig
+}
+
+moved {
+  from = module.phases.local_sensitive_file.ssh_key
+  to   = module.nodep.local_sensitive_file.ssh_key
+}
+
+# L2: Environment & Networking (Secrets/Infisical/Postgres)
+moved {
+  from = module.phases.kubernetes_namespace.iac
+  to   = module.env_and_networking.kubernetes_namespace.iac
+}
+
+moved {
+  from = module.phases.helm_release.postgresql
+  to   = module.env_and_networking.helm_release.postgresql
+}
+
+moved {
+  from = module.phases.helm_release.infisical
+  to   = module.env_and_networking.helm_release.infisical
+}
+
+moved {
+  from = module.phases.kubernetes_secret.infisical_secrets
+  to   = module.env_and_networking.kubernetes_secret.infisical_secrets
+}
+
+# Infisical Random IDs
+moved {
+  from = module.phases.random_id.infisical_encryption_key
+  to   = module.env_and_networking.random_id.infisical_encryption_key
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_signup_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_signup_secret
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_refresh_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_refresh_secret
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_auth_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_auth_secret
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_service_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_service_secret
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_mfa_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_mfa_secret
+}
+
+moved {
+  from = module.phases.random_id.infisical_jwt_provider_secret
+  to   = module.env_and_networking.random_id.infisical_jwt_provider_secret
+}
+
+# L3: Computing (Dashboard)
+moved {
+  from = module.phases.kubernetes_namespace.dashboard
+  to   = module.computing.kubernetes_namespace.dashboard
+}
+
+moved {
+  from = module.phases.kubernetes_service_account.dashboard
+  to   = module.computing.kubernetes_service_account.dashboard
+}
+
+moved {
+  from = module.phases.helm_release.kubernetes_dashboard
+  to   = module.computing.helm_release.kubernetes_dashboard
+}
+
+moved {
+  from = module.phases.kubernetes_service_account.dashboard_admin
+  to   = module.computing.kubernetes_service_account.dashboard_admin
+}
+
+moved {
+  from = module.phases.kubernetes_cluster_role_binding.dashboard_admin
+  to   = module.computing.kubernetes_cluster_role_binding.dashboard_admin
+}
+
+moved {
+  from = module.phases.kubernetes_secret.dashboard_admin_token
+  to   = module.computing.kubernetes_secret.dashboard_admin_token
+}


### PR DESCRIPTION
Adds moved.tf to fix CI state regression caused by module renaming. Includes updated 0.check_now.md context.