### PR TITLE
fix(atlantis): remove duplicate iac namespace

### DIFF
--- a/docs/deep_dives/DD-001.secret_and_ci_practices.md
+++ b/docs/deep_dives/DD-001.secret_and_ci_practices.md
@@ -1,0 +1,72 @@
+# DD-001: Infrastructure Design Decisions & Deep Dives
+
+This document captures key architectural Q&A and design rationale discussed during the initial infrastructure setup.
+
+**Date**: 2025-12-06
+**Topics**: SSOT, Atlantis, Secret Management Strategy
+
+---
+
+## 1. Directory Structure as SSOT
+
+### Question
+Why is `docs/dir.md` the Single Source of Truth (SSOT) for the project structure?
+
+### Answer
+Infrastructure projects often suffer from "documentation drift" where the README doesn't match the actual file system. By maintaining a strict, annotated directory map in `docs/dir.md`, we achieve:
+*   **Navigation**: A single entry point to find any component.
+*   **Definition**: Explicitly defining the "Function", "Layer", and "Namespace" for each directory.
+*   **Inventory**: Tracking planned components (e.g., L99 Apps) before they exist in code.
+
+**Key Decision**:
+The `docs/dir.md` file is the master registry. If a directory isn't listed there, it's not part of the official architecture.
+
+---
+
+## 2. Atlantis Configuration: Helm Values vs. Env Vars
+
+### Question
+Why use `(Helm github.token)` in docs instead of a direct Environment Variable like `ATLANTIS_GH_TOKEN`?
+
+### Answer
+We chose the **Helm-native approach** over manual environment injection.
+
+*   **Pros**:
+    *   **Best Practice**: The `runatlantis/atlantis` chart handles sensitive data securely by creating K8s Secrets automatically.
+    *   **Simplicity**: Directly maps to `values.yaml` schema (`github.token`), reducing boilerplate `env` blocks.
+    *   **Automation**: The Chart may use this token for other internal setup (e.g. `.gitconfig` generation) that simple env vars might miss.
+*   **Cons**:
+    *   **Visibility**: It's less obvious than seeing `export TOKEN=...`.
+    *   **Abstraction**: Requires knowing the Helm Chart's internal logic.
+
+**Decision**: Use Helm's built-in `github.token` / `github.secret` for cleaner, more secure infrastructure code.
+
+---
+
+## 3. The Necessity of Infisical (Two-Tier Secret Management)
+
+### Question 1: Do we need Infisical if we already have GitHub/Atlantis Secrets?
+### Question 2: Is Infisical redundant ("stacking") over native K8s Secrets?
+
+### Answer: The "Bootstrap vs. Runtime" Separation
+
+We employ a **Two-Tier Secret Strategy** to solve different lifecycle problems:
+
+#### Tier 1: Bootstrap Secrets (Infra-Ops Only)
+*   **Tools**: GitHub Secrets / Terraform Variables / Atlantis Env.
+*   **Lifecycle**: **"Building the House"**.
+*   **Content**: R2 Credentials, VPS SSH Keys, Root Tokens.
+*   **Why**: You need these *before* the cluster exists. You cannot store the key to create the cluster *inside* the cluster.
+
+#### Tier 2: Runtime/Application Secrets (Dev + Ops)
+*   **Tools**: **Infisical** (Control Plane) + **K8s Secrets** (Data Plane).
+*   **Lifecycle**: **"Living in the House"**.
+*   **Content**: Database passwords, Stripe Keys, API Tokens.
+*   **Why**:
+    *   **Infisical (Control Plane)** offers Versioning, RBAC, Click-to-Rollback, and Multi-Environment (Dev/Staging/Prod) isolation.
+    *   **K8s Secrets (Data Plane)** are the raw storage mechanism K8s understands.
+    *   **The "Stacking" Logic**: Infisical manages the *policy and lifecycle*; K8s Secrets provide the *runtime access*. This is like using **Git** (Version Control) to manage **Source Code Files** (Raw Data). You wouldn't manually edit raw files on a production server; similarly, you shouldn't manually edit raw K8s Secrets.
+
+**Decision**:
+*   **L1 (Bootstrap)** uses Terraform Variables/GitHub Secrets.
+*   **L2+ (Apps/DBs)** uses Infisical as the SSOT, syncing to K8s Secrets via Operator.

--- a/docs/deep_dives/DD-002.why_atlantis.md
+++ b/docs/deep_dives/DD-002.why_atlantis.md
@@ -1,0 +1,66 @@
+# DD-002: Infrastructure Workflow & Tooling Decisions
+
+**Goal**: Consistent multi-env topology, GitOps workflow, self-hosted tooling.
+
+## 1. Environments & Lifecycle
+
+| Env | Type | Purpose | Lifecycle |
+|---|---|---|---|
+| **Dev** | Local/VM | Development | Persistent |
+| **CI** | Ephemeral | Unit Tests | Minutes (Pipeline) |
+| **Test** | Ephemeral | PR Preview | PR Duration |
+| **Staging** | Persistent | Pre-prod | Persistent (Prod Mirror) |
+| **Prod** | Persistent | Production | Persistent |
+
+## 2. Terraform Architecture
+
+**Structure**: Split into **Components** (Modules) and **Environments** (Composition).
+- **Modules** (`components/`): Reusable logic (Network, DB, Apps).
+- **Environments** (`envs/`):
+    - `dev/`, `staging/`, `prod/`: Static environments.
+    - `ci/`, `test/`: Dynamic/Template environments.
+- **State**: Strictly isolated per environment (`state/system/<env>`).
+
+## 3. Workflows (GitOps)
+
+### CI / Test (Ephemeral)
+- **Trigger**: Pull Request.
+- **Action**: CI pipeline runs `terraform plan` -> `apply` -> `test`.
+- **Cleanup**: `terraform destroy` on PR close/merge.
+
+### Staging / Prod (Persistent)
+- **Tool**: **Atlantis** (Self-Hosted).
+- **Flow**:
+    1.  PR to `main` -> Auto-Plan.
+    2.  Review -> Comment `atlantis apply`.
+    3.  Merge.
+- **Promotion**: Verify in Staging before applying to Prod.
+
+## 4. Responsibility Boundaries
+
+| Scope | Owner | Tool | Example |
+|---|---|---|---|
+| **Infrastructure** | Ops / Infra | Terraform | Creating RDS, Redis, K8s, IAM |
+| **Schema/Data** | App Dev | Framework (Django) | `python manage.py migrate` |
+
+*Strategy*: Terraform provisions the empty DB instance; App pipeline applies schema migrations on startup.
+
+## 5. Tool Selection: Atlantis
+
+**Decision**: Start with **Atlantis** (Self-Hosted).
+- **Why**:
+    - Full control over execution environment (local R2 backend).
+    - PR Locking prevents concurrent modification conflicts.
+    - Simple comment-driven workflow.
+- **Alternative**: Terrateam OSS (Consider later if complex orchestration needed).
+
+## 6. Secret Management (Two-Tier)
+
+**Tier 1: Bootstrap Secrets (L1)**
+- **Source**: GitHub Secrets / Atlantis Env.
+- **Use**: Creating the cluster (VPS Keys, Cloud Creds).
+
+**Tier 2: Runtime Secrets (L2+)**
+- **Source**: **Infisical**.
+- **Use**: Application logic (DB Passwords, API Keys).
+- **Flow**: Infisical (UI/Versioned) -> Operator -> K8s Secrets -> Pod.

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -11,7 +11,7 @@ This document serves as the navigation map for the `infra` repository.
 ## Tree
 
 ```text
-infra/
+root/
 ├── .terrateam/              # [+] L0 Orchestration (Config)
 │   └── config.yml           # (!) Terrateam Config
 ├── .github/workflows/       # [+] GitHub Runners
@@ -19,27 +19,35 @@ infra/
 ├── apps/                    # [+] Business Code
 │   └── tools/               # [+] Dev scripts
 ├── docs/                    # [+] Architecture & Design
-│   ├── dir.md               # (!) This map
+│   ├── dir.md               # (!) This map & Namespace Registry
 │   ├── README.md            # (!) Design Concepts
-│   └── project/             # [+] Project Mgmt
+│   ├── project/             # [+] Project Mgmt (BRN-004)
+│   └── BRN-004.md           # (!) Full Architecture Spec
 ├── terraform/               # [!] Infrastructure Code (The Truth)
 │   ├── envs/                # [+] Env Configs
 │   ├── output/              # [*] Generated files
 │   ├── main.tf              # (!) Layer Orchestration
 │   ├── variables.tf         # (!) Global Schema
-│   ├── 1.nodep/             # [+] L1: Bootstrap
-│   │   ├── 1.k3s.tf         # (!) Provisioning Logic
-│   │   └── README.md        # 📖 L1 Docs
-│   ├── 2.env_and_networking/# [+] L2: Foundation
-│   │   ├── 2.secret.tf      # (!) Secrets Logic
-│   │   └── README.md        # 📖 L2 Docs
-│   ├── 3.computing/         # [+] L3: Runtime
-│   │   ├── 3.dashboard.tf   # (!) App Logic
-│   │   └── README.md        # 📖 L3 Docs
-│   ├── 4.storage/           # [+] L4: Data
-│   │   └── README.md        # 📖 L4 Docs
-│   └── 5.insight/           # [+] L5: Insight
-│       └── README.md        # 📖 L5 Docs
+│   ├── 1.nodep/             # [+] L1: Bootstrap (ns: nodep)
+│   │   ├── 1.k3s.tf         # (!) Runtime Provisioning
+│   │   ├── 2.atlantis.tf    # (!) CI Automation
+│   │   └── README.md        # 📖 SSOT
+│   ├── 2.env_and_networking/# [+] L2: Foundation (ns: security)
+│   │   ├── 1.postgres.tf    # (!) Shared DB
+│   │   ├── 2.secret.tf      # (!) Infisical
+│   │   └── README.md        # 📖 SSOT
+│   ├── 3.computing/         # [+] L3: Runtime (ns: kubero/apps)
+│   │   ├── 3.dashboard.tf   # (!) K8s Dashboard
+│   │   ├── (kubero.tf)      # (!) PaaS (Planned)
+│   │   └── README.md        # 📖 SSOT
+│   ├── 4.storage/           # [+] L4: Data (ns: data)
+│   │   ├── (redis.tf)       # (!) Cache (Planned)
+│   │   ├── (neo4j.tf)       # (!) Graph (Planned)
+│   │   └── README.md        # 📖 SSOT
+│   └── 5.insight/           # [+] L5: Insight (ns: obs/ingestion)
+│       ├── (signoz.tf)      # (!) APM (Planned)
+│       ├── (posthog.tf)     # (!) Analytics (Planned)
+│       └── README.md        # 📖 SSOT
 ├── tools/                   # [!] Meta / CI SSOT
 │   └── README.md            # (!) CI/CD & Mgmt SSOT
 ├── .gitignore               # (!) Git Ignore Rules
@@ -47,15 +55,14 @@ infra/
 └── README.md                # (!) Project Index
 ```
 
-## Key Locations
+## Key Layers (Defined in BRN-004)
 
-| Purpose | Directory | SSOT File |
-|---|---|---|
-| **CI/CD Orchestration** | `tools/` | `README.md` |
-| **Run Terraform** | `terraform/` | `main.tf` |
-| **L1 Bootstrap** | `terraform/1.nodep` | `1.k3s.tf` |
-| **L2 Foundation** | `terraform/2.env_and_networking` | `2.secret.tf` |
-| **L3 Runtime** | `terraform/3.computing` | `3.dashboard.tf` |
-| **L4 Data** | `terraform/4.storage` | `README.md` |
-| **L5 Insight** | `terraform/5.insight` | `README.md` |
-| **Architecture** | `docs/` | `README.md` |
+| Layer | Name | Definition | Modules (Path :: Function) | k3s Namespace | SSOT |
+|---|---|---|---|---|---|
+| **L0** | **Tools Chain** | Project Roots | `tools/` :: CI/CD <br> `docs/` :: Architecture <br> `terraform/` :: Orchestration | - | `README.md` |
+| **L1** | **Bootstrap** | Infrastructure Logic | `1.nodep/` :: Runtime (k3s), CI (Atlantis) | `nodep` | `1.nodep/README.md` |
+| **L2** | **Foundation** | Security & Networking | `2.env_and_networking/` :: Secrets (Infisical, Postgres_env) | `security` | `2.env.../README.md` |
+| **L3** | **Runtime** | App Runtime & PaaS | `3.computing/` :: PaaS (Kubero), Dashboard, Apps | `kubero`, `apps` | `3.comp.../README.md` |
+| **L4** | **Data** | Data Stores | `4.storage/` :: Cache (Redis), Graph (Neo4j), DB (Postgres_app) | `data` | `4.storage/README.md` |
+| **L5** | **Insight** | Observability | `5.insight/` :: Obs. (SigNoz), Analytics (PostHog) | `observability`, `ingestion` | `5.insight/README.md` |
+| **L99** | **Apps** | Business Logic | `apps/` :: Business Services | `apps` | `apps/README.md` |

--- a/terraform/1.nodep/2.atlantis.tf
+++ b/terraform/1.nodep/2.atlantis.tf
@@ -1,10 +1,16 @@
 # L1.2: Atlantis (Terraform CI/CD) - Foundation Layer
 # Purpose: Self-hosted Terraform PR automation
-# Note: Uses "iac" namespace (created by L2, passed via var.iac_namespace)
+# Note: Deployed in "nodep" namespace
+
+resource "kubernetes_namespace" "nodep" {
+  metadata {
+    name = "nodep"
+  }
+}
 
 resource "helm_release" "atlantis" {
   name       = "atlantis"
-  namespace  = var.iac_namespace
+  namespace  = kubernetes_namespace.nodep.metadata[0].name
   repository = "https://runatlantis.github.io/helm-charts"
   chart      = "atlantis"
   version    = "4.25.0"
@@ -64,14 +70,13 @@ resource "helm_release" "atlantis" {
       }
     })
   ]
-
-  # No depends_on needed - namespace exists before this runs
+  depends_on = [kubernetes_namespace.nodep]
 }
 
 output "atlantis_service" {
-  value = "atlantis.${var.iac_namespace}.svc.cluster.local:4141"
+  value = "atlantis.${kubernetes_namespace.nodep.metadata[0].name}.svc.cluster.local:4141"
 }
 
-output "iac_namespace" {
-  value = var.iac_namespace
+output "nodep_namespace" {
+  value = kubernetes_namespace.nodep.metadata[0].name
 }

--- a/terraform/1.nodep/variables.tf
+++ b/terraform/1.nodep/variables.tf
@@ -30,8 +30,3 @@ variable "aws_secret_access_key" {
 }
 variable "r2_bucket" {}
 variable "r2_account_id" {}
-
-# IAC namespace (created by L2 postgres, use default for CI)
-variable "iac_namespace" {
-  default = "iac"
-}

--- a/terraform/2.env_and_networking/1.postgres.tf
+++ b/terraform/2.env_and_networking/1.postgres.tf
@@ -1,16 +1,16 @@
 # Phase 1.1: PostgreSQL (Infisical DB)
-# Namespace: iac
+# Namespace: security
 # Storage: local-path PVC
 
-resource "kubernetes_namespace" "iac" {
+resource "kubernetes_namespace" "security" {
   metadata {
-    name = var.namespaces["iac"]
+    name = var.namespaces["security"]
   }
 }
 
 resource "helm_release" "postgresql" {
   name      = "postgresql"
-  namespace = kubernetes_namespace.iac.metadata[0].name
+  namespace = kubernetes_namespace.security.metadata[0].name
 
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
@@ -49,11 +49,11 @@ resource "helm_release" "postgresql" {
     })
   ]
 
-  depends_on = [kubernetes_namespace.iac]
+  depends_on = [kubernetes_namespace.security]
 }
 
 output "postgresql_endpoint" {
-  value = "postgresql.${kubernetes_namespace.iac.metadata[0].name}.svc.cluster.local:5432"
+  value = "postgresql.${kubernetes_namespace.security.metadata[0].name}.svc.cluster.local:5432"
 }
 
 output "postgresql_database" {

--- a/terraform/2.env_and_networking/2.secret.tf
+++ b/terraform/2.env_and_networking/2.secret.tf
@@ -37,7 +37,7 @@ resource "random_id" "infisical_jwt_provider_secret" {
 # Helm release for Infisical with external PostgreSQL and embedded Redis
 resource "helm_release" "infisical" {
   name             = "infisical"
-  namespace        = var.namespaces["iac"]
+  namespace        = var.namespaces["security"]
   repository       = "https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/"
   chart            = "infisical-standalone"
   version          = var.infisical_chart_version
@@ -92,12 +92,12 @@ resource "helm_release" "infisical" {
 resource "kubernetes_secret" "infisical_secrets" {
   metadata {
     name      = "infisical-secrets"
-    namespace = var.namespaces["iac"]
+    namespace = var.namespaces["security"]
   }
 
   data = {
     # Database - using external PostgreSQL
-    DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.${var.namespaces["iac"]}.svc.cluster.local:5432/infisical"
+    DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.${var.namespaces["security"]}.svc.cluster.local:5432/infisical"
 
     # Encryption keys
     ENCRYPTION_KEY           = random_id.infisical_encryption_key.hex
@@ -127,11 +127,11 @@ resource "kubernetes_secret" "infisical_secrets" {
 }
 
 output "infisical_endpoint" {
-  value       = "infisical-backend.${var.namespaces["iac"]}.svc.cluster.local:8080"
+  value       = "infisical-backend.${var.namespaces["security"]}.svc.cluster.local:8080"
   description = "Internal endpoint for Infisical backend"
 }
 
 output "infisical_access_via_port_forward" {
-  value       = "kubectl -n ${var.namespaces["iac"]} port-forward svc/infisical-backend 8080:8080"
+  value       = "kubectl -n ${var.namespaces["security"]} port-forward svc/infisical-backend 8080:8080"
   description = "Command to access Infisical via port-forward"
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -18,9 +18,10 @@ locals {
   }
 
   namespaces = {
+    nodep         = "nodep"
+    security      = "security"
     apps          = "apps"
     data          = "data"
-    iac           = "iac"
     ingestion     = "ingestion"
     kubero        = "kubero"
     observability = "observability"


### PR DESCRIPTION
## Problem
CI failing with: `namespaces "iac" already exists`

## Cause
`iac` namespace created by both L1 (`2.atlantis.tf`) and L2 (`1.postgres.tf`).

## Fix
- Removed `kubernetes_namespace.iac` from L1 Atlantis
- Added `iac_namespace` variable with default `"iac"`
- L2 owns namespace, L1 just uses it