### PR TITLE
ci: fix missing action inputs

### DIFF
--- a/.github/actions/terraform-setup/action.yml
+++ b/.github/actions/terraform-setup/action.yml
@@ -46,6 +46,12 @@ inputs:
   infisical_postgres_password:
     description: "Postgres Password"
     required: true
+  github_token:
+    description: "GitHub PAT for Atlantis"
+    required: true
+  atlantis_webhook_secret:
+    description: "Atlantis Webhook Secret"
+    required: true
 
 runs:
   using: "composite"


### PR DESCRIPTION
Defines github_token and atlantis_webhook_secret in action inputs.