### PR TITLE
Add documentation guard for check_now and READMEs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,5 @@
 # GitHub Automation
 
 CI/CD and bot configuration live here. Workflows under `workflows/` drive Terraform checks and other automation.
+
+Documentation guard: `docs-guard.yml` enforces updating `0.check_now.md` and directory `README.md` files whenever code changes land.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,3 +1,8 @@
 # Workflows
 
 GitHub Actions entrypoints. Keep setup logic shared (e.g., Terraform init/plan/apply) consistent across workflows and align with `AGENTS.md` instructions.
+
+## Inventory
+- `deploy-k3s.yml`: Plans/applies Terraform to deploy k3s to the target VPS.
+- `terraform-plan.yml`: Runs Terraform plan on PRs touching IaC files.
+- `docs-guard.yml`: Fails PRs that do not update `0.check_now.md` and the relevant `README.md` in each changed directory.

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -1,0 +1,24 @@
+name: Documentation Guard
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  docs-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce check_now and README updates
+        run: |
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+          tools/docs-guard.sh "${BASE_SHA}" "${HEAD_SHA}"

--- a/0.check_now.md
+++ b/0.check_now.md
@@ -15,12 +15,19 @@ User requested a better mechanism for tracking "Current Context".
 - **Old Way**: Symlink to specific changelog.
 - **New Way**: This file (`0.check_now.md`) is the **Living Context**. It accumulates context, decisions, and attempts.
 - **Lifecycle**: When this "Sprint" or "Topic" is done, this file is moved to `docs/change_log/YYYY-MM-DD.topic.md` and a new `0.check_now.md` is created.
+- **Documentation Guard**: CI must fail if PRs skip updating this file or the README in any touched directory (see `.github/workflows/docs-guard.yml` + `tools/docs-guard.sh`).
 
 ## 3. Next Steps
-- [ ] Verify CI stability after standardization. (Done - PR #34 Merged)
+- [x] Add CI guard to enforce `0.check_now.md` + README coupling on every PR.
 - [ ] Refactor `0.check_now.md` mechanism (This task).
+- [x] Verify CI stability after standardization. (Done - PR #34 Merged)
 - [ ] Continue with `3.computing` (Kubero) implementation.
 
 ## 4. Notes / Attempts
 - *Attempt 1*: Tried to fix CI via just editing YAMLs. Failed because `fmt` and `ssh` setup drifted.
 - *Attempt 2*: Implemented Composite Action. Success. (See PR #34).
+
+## 5. Validation Checklist
+- [ ] `Documentation Guard` workflow passes on PRs.
+- [ ] `./tools/docs-guard.sh <base> [head]` works locally against main.
+- [ ] Directory READMEs stay in sync with file changes.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ kubectl get pods -A # 查看所有 pods
 - **API Endpoint**：可用域名访问 API，需配置 DNS 指向 VPS。
 - **SSH Key**：tfvars 中使用 heredoc 保留换行。
 
+## 贡献者提示
+
+- 每次变更必须更新 `0.check_now.md`，并同步修改所涉目录的 `README.md`（CI `Documentation Guard` 会检查）。
+- 本地执行 `./tools/docs-guard.sh origin/main` 可提前验证。
+
 ## 后续演进
 
 **BRN-004：Staging 完整部署（phase 内无依赖）**

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,7 +13,7 @@ It serves as the Single Source of Truth (SSOT) for *how* we manage operations, C
 - **Secrets**: Managed via GitHub Repository Settings.
 
 ## 3. Local Scripts
-*(Future home for dev scripts, e.g., setup, verify)*
+- `./tools/docs-guard.sh <base-ref> [head-ref]`: Run the documentation guard locally; CI calls it to ensure `0.check_now.md` and touched directories' `README.md` files are updated together.
 
 ---
 

--- a/tools/docs-guard.sh
+++ b/tools/docs-guard.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: tools/docs-guard.sh <base-ref> [head-ref]
+# Enforces that 0.check_now.md and directory README.md files are updated alongside code changes.
+
+BASE_REF="${1:-}"
+HEAD_REF="${2:-}"
+
+if [[ -z "${BASE_REF}" ]]; then
+  echo "Usage: $0 <base-ref> [head-ref]" >&2
+  exit 2
+fi
+
+if [[ -n "${HEAD_REF}" ]]; then
+  CHANGED_FILES="$(git diff --name-only "${BASE_REF}...${HEAD_REF}")"
+else
+  CHANGED_FILES="$(git diff --name-only "${BASE_REF}")"
+fi
+
+if [[ -z "${CHANGED_FILES}" ]]; then
+  echo "No changes detected between ${BASE_REF} and ${HEAD_REF}."
+  exit 0
+fi
+
+status=0
+
+if ! grep -qx "0.check_now.md" <<< "${CHANGED_FILES}"; then
+  echo "::error::0.check_now.md must be updated for every change."
+  status=1
+fi
+
+dirs=()
+while IFS= read -r file; do
+  [[ -z "${file}" ]] && continue
+  basename="$(basename "${file}")"
+  [[ "${basename}" == "README.md" ]] && continue
+  [[ "${file}" == "0.check_now.md" ]] && continue
+  dir="$(dirname "${file}")"
+  dirs+=("${dir}")
+done <<< "${CHANGED_FILES}"
+
+missing_readmes=()
+missing_updates=()
+
+if ((${#dirs[@]})); then
+  while IFS= read -r dir; do
+    if [[ "${dir}" == "." ]]; then
+      readme_path="README.md"
+    else
+      readme_path="${dir}/README.md"
+    fi
+    if [[ ! -f "${readme_path}" ]]; then
+      missing_readmes+=("${readme_path}")
+      continue
+    fi
+    if ! grep -qx "${readme_path}" <<< "${CHANGED_FILES}"; then
+      missing_updates+=("${readme_path} (required for changes in ${dir})")
+    fi
+  done <<< "$(printf "%s\n" "${dirs[@]}" | sort -u)"
+fi
+
+if (( ${#missing_readmes[@]} )); then
+  echo "::error::Missing README.md files for changed directories: ${missing_readmes[*]}"
+  status=1
+fi
+
+if (( ${#missing_updates[@]} )); then
+  echo "::error::Update these README.md files to match changed directories: ${missing_updates[*]}"
+  status=1
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+  echo "Documentation guard failed."
+  exit 1
+fi
+
+echo "Documentation guard passed: 0.check_now.md and README.md files are aligned."


### PR DESCRIPTION
## Summary
- add Documentation Guard workflow to enforce updating 0.check_now.md and touched directory README.md files
- add reusable tools/docs-guard.sh for local/CI enforcement and error on missing README
- refresh docs (root README, .github, tools) and 0.check_now.md with the new guard

## Testing
- tools/docs-guard.sh origin/main
