### PR TITLE
fix: rollback count design from L1/L2 modules

### DIFF
--- a/0.check_now.md
+++ b/0.check_now.md
@@ -1,7 +1,8 @@
-# 0.check_now — Current Sprint# Check Now
+# Check Now
 
-Status: **Stabilizing CI**
-Last Updated: 2025-12-06
+Status: **Verifying Post-Merge**
+Last Updated: 2025-12-06T23:45
+Verification Branch: verify/post-merge-atlantis-test
 Changes:
 - Fixed Atlantis Quoting for Backend Config.
 - Validating Credential Injection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,6 @@
 # L1: Bootstrap (K3s + Atlantis CI Foundation)
 module "nodep" {
   source = "./1.nodep"
-  count  = var.enable_infra ? 1 : 0
 
   vps_host           = var.vps_host
   vps_user           = var.vps_user
@@ -34,7 +33,6 @@ module "nodep" {
 # L2: Environment & Networking (Secrets + Platform Subs)
 module "env_and_networking" {
   source = "./2.env_and_networking"
-  count  = var.enable_infra ? 1 : 0
 
   infisical_chart_version     = var.infisical_chart_version
   infisical_image_tag         = var.infisical_image_tag


### PR DESCRIPTION
## Summary
Removes the `count = var.enable_infra ? 1 : 0` pattern from L1/L2 modules.

## Why
L1 (nodep) and L2 (env_and_networking) are global singletons by design. Adding `count` caused:
- State path to change from `module.nodep` to `module.nodep[0]`
- State migration complexity
- Confusing `[0]` indexing for singleton resources

## Changes
- Removed `count` from `module.nodep` in `main.tf`
- Removed `count` from `module.env_and_networking` in `main.tf`
- Updated `terraform/envs/README.md` with correct 5-layer architecture documentation

## State Impact
Terraform state has already been migrated locally. This PR aligns the code with the current state.