### PR TITLE
docs(network): align with L1-L5 layer architecture

### DIFF
--- a/terraform/1.nodep/network.md
+++ b/terraform/1.nodep/network.md
@@ -1,6 +1,8 @@
-# Network & Domain SSOT
+# Network & Domain Architecture
 
-## 0. DNS Architecture
+> Aligned with [terraform/envs/README.md](../envs/README.md) 5-Layer Design.
+
+## 1. DNS Architecture
 
 **Cloudflare Wildcard DNS + Ingress Routing**:
 - `*.truealpha.club` → VPS IP (proxied, orange cloud)
@@ -8,39 +10,62 @@
 - `i-k3s` → VPS IP (DNS-only, grey cloud, for port 6443)
 
 All HTTP/HTTPS (80/443) services route through Nginx Ingress Controller.
-Each service defines its own Ingress with specific `host` rule.
 
-## 1. 变量定义 (Definitions)
+## 2. Domain Patterns
 
-| Variable | Description | Example Value | Source |
-|----------|-------------|---------------|--------|
-| `${BASE_DOMAIN}` | 基础域名 | `truealpha.club` | `terraform.tfvars` |
-| `${VPS_HOST}` | 基础 IP | `1.2.3.4` | `terraform.tfvars` (for context) |
-| `${ENV_PREFIX}` | 环境前缀 | `x-staging` | `staging.tfvars` |
+| Pattern | Prefix | Template | Description |
+|---------|--------|----------|-------------|
+| **A** (Global) | `i-` | `i-{service}.${BASE_DOMAIN}` | Singleton/Shared services (L1/L2) |
+| **B** (Env) | `{env}-` | `{env}-{service}.${BASE_DOMAIN}` | Environment-isolated services (L3+) |
 
-## 2. 命名模式 (Patterns)
+**Examples**:
+- Pattern A: `i-atlantis.truealpha.club`, `i-secrets.truealpha.club`
+- Pattern B: `staging-app.truealpha.club`, `prod-signoz.truealpha.club`
 
-### A. 内部服务 (Internal Service)
-*   **Prefix**: `i-`
-*   **Pattern**: `i-{service}.${BASE_DOMAIN}`
-*   **Example**: `i-atlantis.example.com`
+## 3. Service Map by Layer
 
-### B. 环境服务 (Environmental Service)
-*   **Prefix**: `x-`
-*   **Pattern**: `x-{env}-{service}.${BASE_DOMAIN}` (equivalent to `${DOMAIN_PREFIX}-{service}.${BASE_DOMAIN}`)
-*   **Example** (Staging): `x-staging-api.example.com`
+### L1: Bootstrap (Singleton)
 
-## 3. 服务列表 (Service List)
+| Service | Domain | Notes |
+|---------|--------|-------|
+| K3s API | `i-k3s.${BASE_DOMAIN}` | DNS-only (port 6443) |
 
-| Category | Service | `{service}` Name | Pattern | Full Example URL | Managed By |
-|----------|---------|------------------|---------|------------------|------------|
-| **Global** | Atlantis | `atlantis` | **A** | `https://i-atlantis.${BASE_DOMAIN}` | L1 (Nodep) |
-| **Global** | K3s API | `k3s` | **A** | `https://i-k3s.${BASE_DOMAIN}` | L1 (Nodep) |
-| **Env** | Kubero UI | `api` | **B** | `https://${DOMAIN_PREFIX}-api.${BASE_DOMAIN}` | L2 (Networking) |
-| **Env** | Kubero Backend | `api` | **B** | `https://${DOMAIN_PREFIX}-api.${BASE_DOMAIN}` | L2 (Networking) |
-| **Env** | Infisical | `cloud` | **B** | `https://${DOMAIN_PREFIX}-cloud.${BASE_DOMAIN}` | L2 (Networking) |
-| **Env** | SigNoz | `signoz` | **B** | `https://${DOMAIN_PREFIX}-signoz.${BASE_DOMAIN}` | L2 (Observability) |
-| **Env** | PostHog | `posthog` | **B** | `https://${DOMAIN_PREFIX}-posthog.${BASE_DOMAIN}` | L2 (Observability) |
-| **App** | Frontend | (root) | **B***| `https://${DOMAIN_PREFIX}.${BASE_DOMAIN}` | L2 (Networking) |
+### L2: Networking (Singleton)
 
-> *Frontend uses the prefix directly as the subdomain in the environment pattern.
+| Service | Domain | Notes |
+|---------|--------|-------|
+| Atlantis | `i-atlantis.${BASE_DOMAIN}` | Terraform CI/CD |
+| Infisical | `i-secrets.${BASE_DOMAIN}` | Secrets Management |
+| Cert-Manager | N/A | Internal only |
+| Ingress-Nginx | N/A | Internal only |
+
+### L3: Platform (Per-Env)
+
+| Service | Domain | Environments |
+|---------|--------|--------------|
+| Kubero UI | `{env}-kcloud.${BASE_DOMAIN}` | staging, prod |
+| Kubero API | `{env}-kapi.${BASE_DOMAIN}` | staging, prod |
+
+### L4: Data (Per-Env)
+
+| Service | Domain | Environments |
+|---------|--------|--------------|
+| PostgreSQL | N/A (Internal) | staging, prod, temp-* |
+| Redis | N/A (Internal) | staging, prod, temp-* |
+
+### L5: Insight (Per-Env)
+
+| Service | Domain | Environments |
+|---------|--------|--------------|
+| SigNoz | `{env}-signoz.${BASE_DOMAIN}` | staging, prod |
+| PostHog | `{env}-posthog.${BASE_DOMAIN}` | staging, prod |
+| App Frontend | `{env}.${BASE_DOMAIN}` | staging, prod |
+| App Backend | `{env}-api.${BASE_DOMAIN}` | staging, prod |
+
+## 4. Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `${BASE_DOMAIN}` | Root domain | `truealpha.club` |
+| `${VPS_HOST}` | VPS IP | `103.214.23.41` |
+| `{env}` | Environment prefix | `staging`, `prod`, `temp-xyz` |


### PR DESCRIPTION
## Summary
Rewrote `terraform/1.nodep/network.md` to match the 5-layer architecture defined in `terraform/envs/README.md`.

## Changes
- Separated Singleton (L1/L2) services from Isolated (L3+) services
- Corrected layer assignments (Infisical is L2 Singleton, not per-env)
- Added proper domain patterns per layer (Pattern A for Global, Pattern B for Env)

## Verification
✅ `i-secrets.truealpha.club` returns `{"message":"Ok"}`