### PR TITLE
fix(infisical): add GitHub OAuth SSO and fix DB password

### DIFF
--- a/terraform/2.env_and_networking/2.secret.tf
+++ b/terraform/2.env_and_networking/2.secret.tf
@@ -136,8 +136,12 @@ resource "kubernetes_secret" "infisical_secrets" {
     JWT_PROVIDER_AUTH_SECRET = random_id.infisical_jwt_provider_secret.hex
 
     # Site configuration
-    SITE_URL           = "http://infisical.local"
+    SITE_URL           = "https://i-secrets.${var.base_domain}"
     INVITE_ONLY_SIGNUP = "false"
+
+    # GitHub OAuth SSO
+    CLIENT_ID_GITHUB_LOGIN     = var.infisical_github_client_id
+    CLIENT_SECRET_GITHUB_LOGIN = var.infisical_github_client_secret
 
     # SMTP configuration
     SMTP_HOST         = "mailhog"

--- a/terraform/2.env_and_networking/variables.tf
+++ b/terraform/2.env_and_networking/variables.tf
@@ -11,3 +11,14 @@ variable "namespaces" {
 
 variable "vps_host" {} # Needed for A record IF not managed by L1 (Wait, L1 now manages Atlantis DNS)
 # Actually, L2 might still need vps_host for other things, but Cloudflare secrets are moving to L1.
+
+variable "infisical_github_client_id" {
+  description = "GitHub OAuth App Client ID for Infisical SSO"
+  default     = ""
+}
+
+variable "infisical_github_client_secret" {
+  description = "GitHub OAuth App Client Secret for Infisical SSO"
+  default     = ""
+  sensitive   = true
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,6 +51,10 @@ module "env_and_networking" {
   # "variable "vps_host" {} # Needed for A record IF not managed by L1..."
   vps_host             = var.vps_host
 
+  # Infisical GitHub OAuth
+  infisical_github_client_id     = var.infisical_github_client_id
+  infisical_github_client_secret = var.infisical_github_client_secret
+
   depends_on = [module.nodep]
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -86,10 +86,10 @@ variable "env_prefix" {
 
 # Infisical PostgreSQL (dedicated)
 variable "infisical_postgres_password" {
-  description = "PostgreSQL password for Infisical database"
+  description = "PostgreSQL password for Infisical database (REQUIRED - no default for security)"
   type        = string
   sensitive   = true
-  default     = "CHANGE_ME"
+  # No default - must be provided via tfvars or -var flag
 }
 
 variable "infisical_postgres_storage" {
@@ -203,4 +203,17 @@ variable "cloudflare_api_token" {
 variable "cloudflare_zone_id" {
   description = "Cloudflare Zone ID for the domain"
   type        = string
+}
+
+variable "infisical_github_client_id" {
+  description = "GitHub OAuth App Client ID for Infisical SSO"
+  type        = string
+  default     = ""
+}
+
+variable "infisical_github_client_secret" {
+  description = "GitHub OAuth App Client Secret for Infisical SSO"
+  type        = string
+  sensitive   = true
+  default     = ""
 }


### PR DESCRIPTION
## Summary
Codifies the manual fixes applied to restore Infisical after the multi-env refactor.

## Root Cause
`DB_CONNECTION_URI` was using `CHANGE_ME` as password because `infisical_postgres_password` had a dangerous default value.

## Changes
| File | Change |
|------|--------|
| `terraform/variables.tf` | Remove default `CHANGE_ME` password (now required) |
| `terraform/variables.tf` | Add `infisical_github_client_id` and `infisical_github_client_secret` |
| `terraform/main.tf` | Pass GitHub OAuth vars to L2 module |
| `terraform/2.env_and_networking/variables.tf` | Add GitHub OAuth variable definitions |
| `terraform/2.env_and_networking/2.secret.tf` | Add `CLIENT_ID_GITHUB_LOGIN`, `CLIENT_SECRET_GITHUB_LOGIN` |
| `terraform/2.env_and_networking/2.secret.tf` | Fix `SITE_URL` to `https://i-secrets.${var.base_domain}` |

## Verification
✅ Infisical accessible at https://i-secrets.truealpha.club with GitHub SSO login