### PR TITLE
fix(ci): repair Claude review + improve UX

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,30 +9,39 @@ on:
 jobs:
   claude:
     runs-on: ubuntu-latest
-    # Only trigger on PTAL comments, skip bot comments
+    # Trigger on /review, /ask, @claude, or PTAL (legacy)
     if: |
-      contains(github.event.comment.body, 'PTAL') ||
-      contains(github.event.comment.body, '@claude')
+      (
+        contains(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, '/ask') ||
+        contains(github.event.comment.body, '@claude') ||
+        contains(github.event.comment.body, 'PTAL')
+      ) &&
+      !contains(github.event.comment.user.login, '[bot]')
 
     permissions:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Run Claude Review
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             This is a Terraform IaC project with layered architecture (L1-L4).
 
             Behavior:
-            - If comment contains "PTAL": Do a full code review.
-            - If comment contains "@claude": Answer the question asked. If no question, do a full code review.
+            - If comment contains "/review" or "PTAL": Do a full code review.
+            - If comment contains "/ask" or "@claude": Answer the question asked. If no question, do a full code review.
 
             Review criteria (when reviewing):
             1. Structure: Is code in correct layer? Are module boundaries clean?
@@ -41,3 +50,22 @@ jobs:
             4. SSOT: No duplicate config? Secrets handled properly?
 
             Be concise. Reference file:line for specific issues.
+
+      - name: Report Failure
+        if: steps.claude.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ **Claude review failed**
+
+            Possible causes:
+            - \`ANTHROPIC_API_KEY\` secret not configured
+            - API rate limit exceeded
+            - Network error
+
+            Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`
+            });

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -64,13 +64,26 @@ jobs:
         with:
           script: |
             const outcome = '${{ steps.plan.outcome }}';
-            const body = `#### Terraform CI Validation ✅
+            const body = `#### Terraform CI Validation ${outcome === 'success' ? '✅' : '❌'}
 
             **Status**: \`${outcome}\`
 
             ${outcome === 'success' ? '🚀 Triggering Atlantis plan...' : '❌ Fix CI errors before Atlantis plan.'}
 
             > Full plan output available in the workflow logs.
+
+            ---
+            <details>
+            <summary>📋 <b>Available Commands</b></summary>
+
+            | Command | Description |
+            |:---|:---|
+            | \`/review\` | Request AI code review |
+            | \`/ask <question>\` | Ask Claude a question about this PR |
+            | \`atlantis plan\` | Re-run terraform plan |
+            | \`atlantis apply\` | Apply terraform changes |
+
+            </details>
             `;
             await github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary
- Fix Claude review workflow (missing `id-token: write` permission)
- Add user-friendly command triggers (`/review`, `/ask`)
- Show available commands in PR comments
- Auto-report failures with logs link

## What Changed

### `claude.yml`
| Before | After |
|:---|:---|
| ❌ Missing `id-token: write` | ✅ Added permission |
| Triggers: `PTAL`, `@claude` | Triggers: `/review`, `/ask`, `@claude`, `PTAL` |
| Silent failure | Auto-comment with error + logs link |

### `terraform-plan.yml`
- PR comments now show collapsible "Available Commands" section

### `README.md`
- Updated Layer architecture (L1-L5 → L1-L4)
- Added `docs-guard.yml` to workflow table
- Updated Claude usage documentation

## Test plan
- [ ] Merge and comment `/review` on any PR
- [ ] Verify Claude responds (no OIDC error)
- [ ] Verify failure auto-comments if API key missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)