### PR TITLE
fix(ci): add tf_state_key input and auto-import existing ConfigMap

### DIFF
--- a/.github/actions/terraform-setup/README.md
+++ b/.github/actions/terraform-setup/README.md
@@ -18,6 +18,7 @@ A composite GitHub Action that sets up the Terraform environment for CI/CD workf
 | `aws_secret_access_key` | ✓ | AWS Secret Access Key for R2 |
 | `r2_bucket` | ✓ | Cloudflare R2 bucket for state |
 | `r2_account_id` | ✓ | Cloudflare R2 account ID |
+| `tf_state_key` | ✗ | State file key in bucket (default: terraform.tfstate) |
 
 ### L1 Bootstrap: VPS/SSH
 | Input | Required | Description |
@@ -65,4 +66,4 @@ GitHub Secrets → action inputs → env vars → tfvars file → Terraform vari
 See [action.yml](./action.yml) for full implementation.
 
 ---
-*Last updated: 2025-12-07*
+*Last updated: 2025-12-09*

--- a/.github/actions/terraform-setup/action.yml
+++ b/.github/actions/terraform-setup/action.yml
@@ -69,6 +69,10 @@ inputs:
     description: "GitHub App Private Key (PEM) for Atlantis"
     required: false
     default: ""
+  tf_state_key:
+    description: "Terraform state file key in R2 bucket"
+    required: false
+    default: "terraform.tfstate"
 
 runs:
   using: "composite"

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -81,6 +81,20 @@ jobs:
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
 
+      # Import existing k8s resources that Terraform wants to manage
+      # This prevents "already exists" errors when adopting existing resources
+      - name: Import Existing Resources
+        if: github.event_name == 'push'
+        working-directory: terraform
+        env:
+          KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
+        run: |
+          # Import local-path-config ConfigMap if not in state
+          if ! terraform state show module.nodep.kubernetes_config_map_v1.local_path_config 2>/dev/null; then
+            echo "Importing local-path-config ConfigMap..."
+            terraform import module.nodep.kubernetes_config_map_v1.local_path_config kube-system/local-path-config || true
+          fi
+
       # Apply all infrastructure (moved blocks require full apply, not targeted)
       # Note: -target=module.nodep fails when moved.tf has pending resource moves
       - name: Apply Infrastructure


### PR DESCRIPTION
## Summary
- Add missing `tf_state_key` input to terraform-setup action
- Auto-import `local-path-config` ConfigMap before apply

## Problem
Main branch CI failed with:
```
Error: configmaps "local-path-config" already exists
```

The ConfigMap is created by k3s installer but Terraform wants to manage it.

## Solution
1. Add `tf_state_key` input that was used but not defined
2. Add import step before apply that checks if resource is in state, imports if not

## Test plan
- [ ] CI passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)