### PR TITLE
fix(ci): update deploy-k3s.yml paths for flattened directory structure

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -90,14 +90,15 @@ jobs:
       # This prevents "already exists" errors when adopting existing resources
       - name: Import Existing Resources
         if: github.event_name == 'push'
-        working-directory: terraform
+        working-directory: 1.bootstrap
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
         run: |
           # Import local-path-config ConfigMap if not in state
-          if ! terraform state show module.nodep.kubernetes_config_map_v1.local_path_config 2>/dev/null; then
+          # Note: Using flat resource path after directory restructure
+          if ! terraform state show kubernetes_config_map_v1.local_path_config 2>/dev/null; then
             echo "Importing local-path-config ConfigMap..."
-            terraform import module.nodep.kubernetes_config_map_v1.local_path_config kube-system/local-path-config || true
+            terraform import kubernetes_config_map_v1.local_path_config kube-system/local-path-config || true
           fi
 
       # Apply all infrastructure (moved blocks require full apply, not targeted)


### PR DESCRIPTION
Fix the Import Existing Resources step that was still referencing the old `terraform/` directory and `module.nodep.*` resource paths.

Changes:
- `working-directory: terraform` → `working-directory: 1.bootstrap`
- `module.nodep.kubernetes_config_map_v1.local_path_config` → `kubernetes_config_map_v1.local_path_config`