### PR TITLE
refactor(namespace): consolidate L2 namespaces into platform

### DIFF
--- a/2.platform/1.postgres.tf
+++ b/2.platform/1.postgres.tf
@@ -1,16 +1,19 @@
 # Phase 1.1: PostgreSQL (Infisical DB)
-# Namespace: security
+# Namespace: platform (L2 layer convention, previously "security")
 # Storage: local-path PVC
 
-resource "kubernetes_namespace" "security" {
+resource "kubernetes_namespace" "platform" {
   metadata {
-    name = var.namespaces["security"]
+    name = "platform"
+    labels = {
+      "layer" = "L2"
+    }
   }
 }
 
 resource "helm_release" "postgresql" {
   name      = "postgresql"
-  namespace = kubernetes_namespace.security.metadata[0].name
+  namespace = kubernetes_namespace.platform.metadata[0].name
 
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
@@ -49,11 +52,11 @@ resource "helm_release" "postgresql" {
     })
   ]
 
-  depends_on = [kubernetes_namespace.security]
+  depends_on = [kubernetes_namespace.platform]
 }
 
 output "postgresql_endpoint" {
-  value = "postgresql.${kubernetes_namespace.security.metadata[0].name}.svc.cluster.local:5432"
+  value = "postgresql.${kubernetes_namespace.platform.metadata[0].name}.svc.cluster.local:5432"
 }
 
 output "postgresql_database" {

--- a/2.platform/2.secret.tf
+++ b/2.platform/2.secret.tf
@@ -37,7 +37,7 @@ resource "random_id" "infisical_jwt_provider_secret" {
 # Helm release for Infisical with external PostgreSQL and embedded Redis
 resource "helm_release" "infisical" {
   name             = "infisical"
-  namespace        = kubernetes_namespace.security.metadata[0].name
+  namespace        = kubernetes_namespace.platform.metadata[0].name
   repository       = "https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/"
   chart            = "infisical-standalone"
   version          = var.infisical_chart_version
@@ -114,12 +114,12 @@ resource "helm_release" "infisical" {
 resource "kubernetes_secret" "infisical_secrets" {
   metadata {
     name      = "infisical-secrets"
-    namespace = kubernetes_namespace.security.metadata[0].name
+    namespace = kubernetes_namespace.platform.metadata[0].name
   }
 
   data = {
     # Database - using external PostgreSQL
-    DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.${var.namespaces["security"]}.svc.cluster.local:5432/infisical"
+    DB_CONNECTION_URI = "postgresql://infisical:${var.infisical_postgres_password}@postgresql.platform.svc.cluster.local:5432/infisical"
 
     # Encryption keys
     ENCRYPTION_KEY           = random_id.infisical_encryption_key.hex
@@ -156,7 +156,7 @@ resource "kubernetes_secret" "infisical_secrets" {
 resource "kubernetes_ingress_v1" "infisical" {
   metadata {
     name      = "infisical-ingress"
-    namespace = kubernetes_namespace.security.metadata[0].name
+    namespace = kubernetes_namespace.platform.metadata[0].name
     annotations = {
       "cert-manager.io/cluster-issuer" = "letsencrypt-prod"
     }
@@ -193,11 +193,11 @@ resource "kubernetes_ingress_v1" "infisical" {
 }
 
 output "infisical_endpoint" {
-  value       = "infisical-backend.${var.namespaces["security"]}.svc.cluster.local:8080"
+  value       = "infisical-backend.platform.svc.cluster.local:8080"
   description = "Internal endpoint for Infisical backend"
 }
 
 output "infisical_access_via_port_forward" {
-  value       = "kubectl -n ${var.namespaces["security"]} port-forward svc/infisical-backend 8080:8080"
+  value       = "kubectl -n platform port-forward svc/infisical-backend 8080:8080"
   description = "Command to access Infisical via port-forward"
 }

--- a/2.platform/4.kubero.tf
+++ b/2.platform/4.kubero.tf
@@ -44,6 +44,7 @@ resource "kubernetes_namespace" "kubero_operator_system" {
     name = "kubero-operator-system"
     labels = {
       "control-plane" = "controller-manager"
+      "layer"         = "L2"
     }
   }
 }
@@ -73,6 +74,9 @@ resource "kubectl_manifest" "kubero_operator" {
 resource "kubernetes_namespace" "kubero" {
   metadata {
     name = "kubero"
+    labels = {
+      "layer" = "L2"
+    }
   }
 
   depends_on = [kubectl_manifest.kubero_operator]

--- a/2.platform/README.md
+++ b/2.platform/README.md
@@ -2,15 +2,15 @@
 
 **Scope**:
 - **Secrets**: Infisical (Self-hosted secrets management)
-- **Platform DB**: PostgreSQL (for Infisical, NOT business data)
+- **Platform DB**: PostgreSQL, Redis (for Infisical)
 - **Dashboard**: Kubernetes Dashboard (cluster web UI)
-- **PaaS**: Kubero (Heroku-like GitOps) [Planned]
-- **Namespaces**: `iac`, `kubernetes-dashboard`
+- **PaaS**: Kubero (Heroku-like GitOps)
+- **Namespaces**: `platform` (main), `kubero`, `kubero-operator-system`
 
 ## Architecture
 
 This layer provides platform-level components that support application deployment.
-Depends on L1 (nodep) for K8s cluster availability.
+Depends on L1 (bootstrap) for K8s cluster availability.
 
 ### Components
 

--- a/2.platform/moved.tf
+++ b/2.platform/moved.tf
@@ -1,0 +1,27 @@
+# Migration History for L2 Platform
+# ============================================================
+# This file contains `moved` blocks that track Terraform state migrations.
+# These blocks are REQUIRED to maintain state continuity across refactoring.
+# Removing them may cause Terraform to treat resources as new (data loss risk).
+#
+# Phase 1: security → platform namespace rename
+# Phase 2: kubernetes-dashboard namespace merged into platform
+# ============================================================
+
+# ============================================================
+# Phase 1: security → platform (namespace and resource renames)
+# ============================================================
+
+moved {
+  from = kubernetes_namespace.security
+  to   = kubernetes_namespace.platform
+}
+
+# ============================================================
+# Phase 2: kubernetes-dashboard → platform (namespace merge)
+# Dashboard resources moved to platform namespace
+# ============================================================
+
+# Note: kubernetes_namespace.dashboard is DELETED, not moved
+# Resources in dashboard namespace will be recreated in platform namespace
+# This is intentional as Dashboard is stateless


### PR DESCRIPTION
## Summary
Phase 2 of namespace architecture redesign per AGENTS.md L1-L4 convention.

## Changes

### Namespace Consolidation
- `security` → `platform` namespace (with `layer=L2` label)
- `kubernetes-dashboard` namespace **removed**, all resources moved to `platform`
- `kubero` / `kubero-operator-system`: kept separate but added `layer=L2` labels

### Files Modified
| File | Change |
|------|--------|
| `1.postgres.tf` | Renamed namespace from `security` to `platform` |
| `2.secret.tf` | Updated all namespace references |
| `3.dashboard.tf` | Removed dashboard namespace, merged to platform |
| `4.kubero.tf` | Added layer labels (kept separate due to operator CRD architecture) |
| `README.md` | Updated documentation |
| `moved.tf` | **NEW** - State migration blocks |

## Migration
The `moved.tf` file ensures Terraform state is migrated for the `security` → `platform` namespace rename.

> ⚠️ **Note**: Dashboard resources will be recreated in the new namespace as it's stateless. PostgreSQL/Redis PVC data needs manual backup if in production.