### PR TITLE
Fix Vault migration CI: storage retain + secrets

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -56,7 +56,7 @@ jobs:
           k3s_api_endpoint: ${{ secrets.K3S_API_ENDPOINT }}
           k3s_channel: ${{ secrets.K3S_CHANNEL }}
           k3s_version: ${{ secrets.K3S_VERSION }}
-          vault_postgres_password: ${{ secrets.INFISICAL_POSTGRES_PASSWORD }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
           github_token: ${{ secrets.GH_PAT || github.token }}
           atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -65,8 +65,6 @@ jobs:
           github_app_id: ${{ secrets.ATLANTIS_GH_APP_ID }}
           github_app_key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
           atlantis_web_password: ${{ secrets.ATLANTIS_WEB_PASSWORD }}
-          infisical_github_client_id: ${{ secrets.INFISICAL_GITHUB_CLIENT_ID }}
-          infisical_github_client_secret: ${{ secrets.INFISICAL_GITHUB_CLIENT_SECRET }}
 
       - name: Terraform plan (L1)
         working-directory: 1.bootstrap
@@ -77,15 +75,6 @@ jobs:
         run: |
           chmod +x 0.tools/preflight-check.sh
           0.tools/preflight-check.sh
-
-      # Emergency Fix: Delete broken webhook that blocks Ingress updates
-      # When Ingress Controller pod is gone but WebhookConfig remains, all Ingress updates fail.
-      - name: Cleanup Broken Webhooks
-        if: github.event_name == 'push'
-        run: |
-          kubectl delete validatingwebhookconfiguration infisical-ingress-nginx-admission --ignore-not-found=true
-        env:
-          KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
 
       # Import existing k8s resources that Terraform wants to manage
       # This prevents "already exists" errors when adopting existing resources
@@ -131,7 +120,7 @@ jobs:
           k3s_api_endpoint: ${{ secrets.K3S_API_ENDPOINT }}
           k3s_channel: ${{ secrets.K3S_CHANNEL }}
           k3s_version: ${{ secrets.K3S_VERSION }}
-          infisical_postgres_password: ${{ secrets.INFISICAL_POSTGRES_PASSWORD }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
           github_token: ${{ secrets.GH_PAT || github.token }}
           atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -140,8 +129,6 @@ jobs:
           github_app_id: ${{ secrets.ATLANTIS_GH_APP_ID }}
           github_app_key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
           atlantis_web_password: ${{ secrets.ATLANTIS_WEB_PASSWORD }}
-          infisical_github_client_id: ${{ secrets.INFISICAL_GITHUB_CLIENT_ID }}
-          infisical_github_client_secret: ${{ secrets.INFISICAL_GITHUB_CLIENT_SECRET }}
 
       - name: Terraform plan (L2)
         working-directory: 2.platform

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -45,7 +45,7 @@ jobs:
           k3s_api_endpoint: ${{ secrets.K3S_API_ENDPOINT }}
           k3s_channel: ${{ secrets.K3S_CHANNEL }}
           k3s_version: ${{ secrets.K3S_VERSION }}
-          vault_postgres_password: ${{ secrets.INFISICAL_POSTGRES_PASSWORD }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
           github_token: ${{ secrets.GH_PAT || github.token }}
           atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -73,7 +73,7 @@ jobs:
           k3s_api_endpoint: ${{ secrets.K3S_API_ENDPOINT }}
           k3s_channel: ${{ secrets.K3S_CHANNEL }}
           k3s_version: ${{ secrets.K3S_VERSION }}
-          infisical_postgres_password: ${{ secrets.INFISICAL_POSTGRES_PASSWORD }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
           github_token: ${{ secrets.GH_PAT || github.token }}
           atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -82,8 +82,6 @@ jobs:
           github_app_id: ${{ secrets.ATLANTIS_GH_APP_ID }}
           github_app_key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
           atlantis_web_password: ${{ secrets.ATLANTIS_WEB_PASSWORD }}
-          infisical_github_client_id: ${{ secrets.INFISICAL_GITHUB_CLIENT_ID }}
-          infisical_github_client_secret: ${{ secrets.INFISICAL_GITHUB_CLIENT_SECRET }}
 
       # ============================================================
       # Static Analysis (runs before plan to catch issues early)

--- a/0.check_now.md
+++ b/0.check_now.md
@@ -199,7 +199,7 @@ basicAuth = {
 
 ### 改动
 - 删除 Infisical 部署与相关随机密钥，改用 Vault（Helm 官方 Chart 0.31.0）
-- Vault 使用 PostgreSQL 作为 storage backend（用户名/库改为 `vault`，StorageClass `local-path-retain`）
+  - Vault 使用 PostgreSQL 作为 storage backend（用户名/库改为 `vault`，StorageClass `local-path-retain` 保留数据）
 - 启用 Vault Agent Injector，Ingress 仍用 `i-secrets.<base_domain>`（TLS 由 cert-manager）
 - CI inputs/变量重命名为 `vault_*`；tfvars 示例、平台/目录文档同步到 Vault
 
@@ -216,18 +216,17 @@ listener "tcp" { address = "0.0.0.0:8200"; tls_disable = "true" }
 ### 修改的文件
 | File | Change |
 |------|--------|
-| `2.platform/1.postgres.tf` | PG 用户/库改为 vault，沿用 local-path-retain |
+| `2.platform/1.postgres.tf` | PG 用户/库改为 vault，StorageClass 使用 `local-path-retain`，启用 `force_update` 便于替换 StatefulSet |
 | `2.platform/2.secret.tf` | Vault Helm（PostgreSQL backend + injector + ingress） |
 | `2.platform/variables.tf`, `1.bootstrap/variables.tf` | 变量重命名为 `vault_*` |
 | `.github/actions/terraform-setup/action.yml` | 输入改为 `vault_postgres_password`，写入 tfvars |
-| `.github/workflows/terraform-plan.yml`, `deploy-k3s.yml` | 传递 Vault 密码输入 |
+| `.github/workflows/terraform-plan.yml`, `deploy-k3s.yml` | 使用 `VAULT_POSTGRES_PASSWORD`，移除 Infisical 变量引用 |
 | `2.platform/README.md`, `docs/dir.md`, `1.bootstrap/network.md`, `.github/actions/terraform-setup/README.md`, `3.data/README.md` | 文档更新为 Vault |
 
 ### 验证清单
-- [ ] `terraform fmt -check` 通过
+- [x] `terraform fmt -check` 通过
 - [ ] Vault Helm Release 部署（Pods Running/Sealed）在 `platform` 命名空间
 - [ ] Ingress `i-secrets.<base_domain>` 正常解析/路由到 Vault service:8200
 - [ ] Agent Injector Pods Ready
 - [ ] PostgreSQL PVC 位于 `local-path-retain`（数据未被删除）
 - [ ] 手动完成 Vault init/unseal，记录 root token/keys（离线）
->>>>>>> 8cf4d25 (platform: replace infisical with vault)

--- a/2.platform/1.postgres.tf
+++ b/2.platform/1.postgres.tf
@@ -18,6 +18,8 @@ resource "helm_release" "postgresql" {
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
   version    = "15.5.0"
+  # Allow StatefulSet spec replacements when auth/storage change
+  force_update = true
 
   values = [
     yamlencode({

--- a/2.platform/README.md
+++ b/2.platform/README.md
@@ -49,7 +49,8 @@ terraform apply
 ### Known Issues
 
 - **Vault init/unseal**: Manual init/unseal required after deploy; store keys outside Terraform.
-- **PostgreSQL storage**: Uses StorageClass `local-path-retain`. PVC deletion leaves data on disk.
+- **PostgreSQL storage**: Uses `local-path-retain` StorageClass (reclaimPolicy=Retain) to keep PV data after PVC deletion.
+- **PostgreSQL upgrades**: `helm_release.postgresql` uses `force_update=true` to allow spec changes (e.g., auth tweaks). Expect pod recreation/downtime during upgrades.
 
 ### Disaster Recovery
 

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -60,14 +60,8 @@ root/
 
 | Layer | Name | Definition | Modules (Path :: Function) | k3s Namespace | SSOT |
 |---|---|---|---|---|---|
-<<<<<<< HEAD
 | **L0** | **Tools Chain** | Project Roots | `0.tools/` :: Scripts <br> `docs/` :: Architecture | - | `README.md` |
-| **L1** | **Bootstrap** | Zero-Dependency Infra | `1.bootstrap/` :: Runtime (k3s), CI (Atlantis), DNS/Cert | `kube-system`, `nodep` | `1.bootstrap/README.md` |
-| **L2** | **Platform** | Platform Components | `2.platform/` :: Secrets (Infisical), Dashboard, Kubero, Platform DB | `iac`, `kubernetes-dashboard` | `2.platform/README.md` |
-=======
-| **L0** | **Tools Chain** | Project Roots | `tools/` :: CI/CD <br> `docs/` :: Architecture <br> `terraform/` :: Orchestration | - | `README.md` |
-| **L1** | **Bootstrap** | Zero-Dependency Infra | `1.nodep/` :: Runtime (k3s), CI (Atlantis), DNS/Cert | `kube-system` | `1.nodep/README.md` |
-| **L2** | **Platform** | Platform Components | `2.platform/` :: Secrets (Vault), Dashboard, Kubero, Platform DB | `platform` | `2.platform/README.md` |
->>>>>>> 8cf4d25 (platform: replace infisical with vault)
+| **L1** | **Bootstrap** | Zero-Dependency Infra | `1.bootstrap/` :: Runtime (k3s), CI (Atlantis), DNS/Cert | `kube-system`, `bootstrap` | `1.bootstrap/README.md` |
+| **L2** | **Platform** | Platform Components | `2.platform/` :: Secrets (Vault), Dashboard, Kubero, Platform DB | `platform`, `kubero`, `kubero-operator-system` | `2.platform/README.md` |
 | **L3** | **Data** | Business Data Stores | `3.data/` :: Cache (Redis), Graph (Neo4j), DB (Postgres), OLAP (ClickHouse) | `data` | `3.data/README.md` |
 | **L4** | **Apps** | Applications | `4.apps/` :: Business Services (prod/staging) | `apps` | `4.apps/README.md` |


### PR DESCRIPTION
## Summary
- keep platform Postgres on local-path-retain with force_update to allow spec changes without data loss
- switch CI workflows to VAULT_POSTGRES_PASSWORD and remove Infisical inputs
- update docs/checklist for Vault swap and 4-layer layout

## Testing
- terraform fmt -check