### PR TITLE
refactor(vault): switch from PostgreSQL to Raft integrated storage

### DIFF
--- a/2.platform/1.postgres.tf
+++ b/2.platform/1.postgres.tf
@@ -1,6 +1,6 @@
-# Platform PostgreSQL (Vault storage backend)
+# Platform PostgreSQL (Available for L2 services - Vault uses Raft storage)
 # Namespace: platform (L2)
-# Storage: local-path PVC (Retain)
+# Storage: local-path-retain PVC
 
 resource "kubernetes_namespace" "platform" {
   metadata {


### PR DESCRIPTION
Switches Vault storage backend from PostgreSQL to Raft integrated storage with PVC. Removes external DB dependency and simplifies architecture.