### PR TITLE
feat(ci): add /dig command for service health check

### DIFF
--- a/.github/workflows/dig.yml
+++ b/.github/workflows/dig.yml
@@ -1,0 +1,168 @@
+name: Service Health Check (/dig)
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  dig:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.comment.body, '/dig')
+
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Create initial comment
+        id: create-comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ## Service Health Check
+
+            <details open>
+            <summary>Testing connectivity...</summary>
+
+            | Layer | Service | Domain | Status |
+            |-------|---------|--------|--------|
+            | - | - | Scanning... | :hourglass: |
+
+            </details>
+
+            ---
+            _Last updated: ${{ github.event.comment.created_at }}_
+
+      - name: Run health checks
+        id: health-check
+        env:
+          BASE_DOMAIN: ${{ secrets.BASE_DOMAIN }}
+        run: |
+          if [ -z "$BASE_DOMAIN" ]; then
+            echo "ERROR: BASE_DOMAIN secret not configured"
+            echo "table=| Error | BASE_DOMAIN secret not configured | - | :x: |" >> "$GITHUB_OUTPUT"
+            echo "summary=:x: Configuration error" >> "$GITHUB_OUTPUT"
+            echo "ok_count=0" >> "$GITHUB_OUTPUT"
+            echo "error_count=1" >> "$GITHUB_OUTPUT"
+            echo "total=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Define services to check (Layer|Name|Subdomain pattern)
+          # Subdomain patterns: i-xxx for internal, empty for root, xxx for standard subdomain
+          SERVICES=(
+            "L1|K3s API|i-k3s:6443"
+            "L1|Atlantis|i-atlantis"
+            "L2|Vault|i-secrets"
+            "L2|K8s Dashboard|i-kdashboard"
+            "L2|Kubero UI|i-kcloud"
+            "L2|Kubero API|i-kapi"
+            "L4|SigNoz|i-signoz"
+            "L4|PostHog|i-posthog"
+            "Prod|Root|@"
+            "Prod|API|api"
+          )
+
+          # Function to check a single service
+          check_service() {
+            local domain="$1"
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 "https://${domain}" 2>/dev/null || echo "000")
+            echo "$code"
+          }
+
+          # Function to get status emoji
+          get_status() {
+            local code="$1"
+            case "$code" in
+              200) echo ":white_check_mark: 200 OK" ;;
+              401|403) echo ":lock: $code Auth Required" ;;
+              404) echo ":grey_question: 404 No Backend" ;;
+              502) echo ":x: 502 Bad Gateway" ;;
+              503) echo ":warning: 503 Unavailable" ;;
+              504) echo ":x: 504 Timeout" ;;
+              526) echo ":warning: 526 SSL Error" ;;
+              000) echo ":no_entry: Timeout/Unreachable" ;;
+              *) echo ":question: $code" ;;
+            esac
+          }
+
+          # Build results table
+          TABLE="| Layer | Service | Domain | Status |"
+          TABLE+="\n|-------|---------|--------|--------|"
+
+          OK_COUNT=0
+          WARN_COUNT=0
+          ERROR_COUNT=0
+
+          for entry in "${SERVICES[@]}"; do
+            IFS='|' read -r layer service subdomain <<< "$entry"
+
+            # Build full domain
+            if [ "$subdomain" = "@" ]; then
+              domain="${BASE_DOMAIN}"
+            elif [[ "$subdomain" == *":"* ]]; then
+              # Has port (e.g., i-k3s:6443)
+              sub="${subdomain%%:*}"
+              port="${subdomain##*:}"
+              domain="${sub}.${BASE_DOMAIN}:${port}"
+            else
+              domain="${subdomain}.${BASE_DOMAIN}"
+            fi
+
+            code=$(check_service "$domain")
+            status=$(get_status "$code")
+            TABLE+="\n| $layer | $service | \`$domain\` | $status |"
+
+            # Count by status
+            case "$code" in
+              200|401|403) ((OK_COUNT++)) ;;
+              503|526) ((WARN_COUNT++)) ;;
+              *) ((ERROR_COUNT++)) ;;
+            esac
+          done
+
+          TOTAL=${#SERVICES[@]}
+
+          # Summary
+          if [ "$ERROR_COUNT" -gt 0 ]; then
+            SUMMARY=":red_circle: $ERROR_COUNT errors"
+          elif [ "$WARN_COUNT" -gt 0 ]; then
+            SUMMARY=":yellow_circle: $WARN_COUNT warnings"
+          else
+            SUMMARY=":green_circle: All systems operational"
+          fi
+
+          # Save to output (use delimiter for multiline)
+          {
+            echo "table<<EOFTABLE"
+            echo -e "$TABLE"
+            echo "EOFTABLE"
+            echo "summary=$SUMMARY"
+            echo "ok_count=$OK_COUNT"
+            echo "warn_count=$WARN_COUNT"
+            echo "error_count=$ERROR_COUNT"
+            echo "total=$TOTAL"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update comment with results
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.create-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            ## Service Health Check ${{ steps.health-check.outputs.summary }}
+
+            <details open>
+            <summary>Results: ${{ steps.health-check.outputs.ok_count }}/${{ steps.health-check.outputs.total }} healthy</summary>
+
+            ${{ steps.health-check.outputs.table }}
+
+            </details>
+
+            ---
+            _Checked at: ${{ github.event.comment.created_at }} | Triggered by @${{ github.event.comment.user.login }}_


### PR DESCRIPTION
## Summary
- Add `/dig` slash command to check service connectivity from PR comments
- Tests all L1-L4 services and posts a live-updating table with status emoji
- Uses `BASE_DOMAIN` secret - no hardcoded domains exposed

## Usage
Comment `/dig` on any PR to trigger health check.

## Test plan
- [ ] Merge PR
- [ ] Open a new PR and comment `/dig`
- [ ] Verify bot creates comment with "Testing connectivity..."
- [ ] Verify comment updates with results table

🤖 Generated with [Claude Code](https://claude.com/claude-code)