### PR TITLE
fix(ci): fix /dig counter bug causing workflow failure

### DIFF
--- a/.github/workflows/dig.yml
+++ b/.github/workflows/dig.yml
@@ -120,9 +120,9 @@ jobs:
 
             # Count by status
             case "$code" in
-              200|401|403) ((OK_COUNT++)) ;;
-              503|526) ((WARN_COUNT++)) ;;
-              *) ((ERROR_COUNT++)) ;;
+              200|401|403) OK_COUNT=$((OK_COUNT + 1)) ;;
+              503|526) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+              *) ERROR_COUNT=$((ERROR_COUNT + 1)) ;;
             esac
           done
 


### PR DESCRIPTION
## Summary
- Fix bash arithmetic bug in `/dig` workflow
- `((var++))` returns exit code 1 when var is 0, causing script failure
- Use `$((var + 1))` assignment instead

## Test plan
- [ ] Merge this PR
- [ ] Comment `/dig` on any PR to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)