### PR TITLE
fix(cert): correct YAML indentation for Certificate dnsNames

### DIFF
--- a/1.bootstrap/locals.tf
+++ b/1.bootstrap/locals.tf
@@ -62,8 +62,8 @@ locals {
     "*.${local.internal_domain}"
   ]))
 
-  base_cert_domains_yaml     = join("\n        ", [for d in local.base_cert_domains : "- \"${d}\""])
-  internal_cert_domains_yaml = join("\n        ", [for d in local.internal_cert_domains : "- \"${d}\""])
+  base_cert_domains_yaml     = join("\n", [for d in local.base_cert_domains : "          - \"${d}\""])
+  internal_cert_domains_yaml = join("\n", [for d in local.internal_cert_domains : "          - \"${d}\""])
 }
 
 data "cloudflare_zones" "internal" {


### PR DESCRIPTION
## Issue
CI failed with cert-manager webhook rejecting empty dnsNames.

## Root Cause
YAML heredoc indentation was wrong - first dnsNames entry had no indent.

## Fix
Each line now includes proper 10-space prefix for correct YAML structure.