### PR TITLE
fix(bootstrap): robust YAML indentation for dnsNames (fix CI)

### DIFF
--- a/1.bootstrap/3.dns_and_cert.tf
+++ b/1.bootstrap/3.dns_and_cert.tf
@@ -110,7 +110,7 @@ resource "null_resource" "wildcard_certificate_public" {
           name: letsencrypt-prod
           kind: ClusterIssuer
         dnsNames:
-${local.base_cert_domains_yaml}
+          ${replace(local.base_cert_domains_yaml, "\n", "\n          ")}
       EOF
     EOT
   }

--- a/1.bootstrap/locals.tf
+++ b/1.bootstrap/locals.tf
@@ -62,8 +62,8 @@ locals {
     "*.${local.internal_domain}"
   ]))
 
-  base_cert_domains_yaml     = join("\n", [for d in local.base_cert_domains : "          - \"${d}\""])
-  internal_cert_domains_yaml = join("\n", [for d in local.internal_cert_domains : "          - \"${d}\""])
+  base_cert_domains_yaml     = yamlencode(local.base_cert_domains)
+  internal_cert_domains_yaml = yamlencode(local.internal_cert_domains)
 }
 
 data "cloudflare_zones" "internal" {


### PR DESCRIPTION
## Issue
CI on main failed with `yaml: line 15: could not find expected ':'` because of incorrect indentation in `dnsNames` list generated by string interpolation.

## Fix
- Use `yamlencode()` in `locals.tf` to safely serialize the list of domains.
- Use `replace()` in `3.dns_and_cert.tf` to inject correct indentation (10 spaces) for the list items.

This ensures valid YAML structure regardless of content.