### PR TITLE
fix(bootstrap): properly format certificate dnsNames YAML indentation

### DIFF
--- a/1.bootstrap/3.dns_and_cert.tf
+++ b/1.bootstrap/3.dns_and_cert.tf
@@ -99,19 +99,19 @@ resource "null_resource" "wildcard_certificate_public" {
   provisioner "local-exec" {
     command = <<-EOT
       kubectl --kubeconfig=${local.kubeconfig_path} apply -f - <<EOF
-      apiVersion: cert-manager.io/v1
-      kind: Certificate
-      metadata:
-        name: wildcard-tls-public
-        namespace: ${kubernetes_namespace.cert_manager.metadata[0].name}
-      spec:
-        secretName: wildcard-tls-public
-        issuerRef:
-          name: letsencrypt-prod
-          kind: ClusterIssuer
-        dnsNames:
-          ${replace(local.base_cert_domains_yaml, "\n", "\n          ")}
-      EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls-public
+  namespace: ${kubernetes_namespace.cert_manager.metadata[0].name}
+spec:
+  secretName: wildcard-tls-public
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+${local.base_cert_domains_yaml}
+EOF
     EOT
   }
 
@@ -126,19 +126,19 @@ resource "null_resource" "wildcard_certificate_internal" {
   provisioner "local-exec" {
     command = <<-EOT
       kubectl --kubeconfig=${local.kubeconfig_path} apply -f - <<EOF
-      apiVersion: cert-manager.io/v1
-      kind: Certificate
-      metadata:
-        name: wildcard-tls-internal
-        namespace: ${kubernetes_namespace.cert_manager.metadata[0].name}
-      spec:
-        secretName: wildcard-tls-internal
-        issuerRef:
-          name: letsencrypt-prod
-          kind: ClusterIssuer
-        dnsNames:
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls-internal
+  namespace: ${kubernetes_namespace.cert_manager.metadata[0].name}
+spec:
+  secretName: wildcard-tls-internal
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
 ${local.internal_cert_domains_yaml}
-      EOF
+EOF
     EOT
   }
 

--- a/1.bootstrap/locals.tf
+++ b/1.bootstrap/locals.tf
@@ -62,8 +62,9 @@ locals {
     "*.${local.internal_domain}"
   ]))
 
-  base_cert_domains_yaml     = yamlencode(local.base_cert_domains)
-  internal_cert_domains_yaml = yamlencode(local.internal_cert_domains)
+  # Format dnsNames as indented YAML list items for Certificate resources
+  base_cert_domains_yaml     = join("\n", [for d in local.base_cert_domains : "    - \"${d}\""])
+  internal_cert_domains_yaml = join("\n", [for d in local.internal_cert_domains : "    - \"${d}\""])
 }
 
 data "cloudflare_zones" "internal" {


### PR DESCRIPTION
## Problem

CI failing with YAML parse error in L1 bootstrap:
```
error converting YAML to JSON: yaml: line 12: did not find expected '-' indicator
```

The previous fix using `yamlencode + replace` was producing malformed YAML:
```yaml
dnsNames:
  - "example.com"
        - "*.example.com"
```

## Solution

1. Remove leading indentation from heredoc YAML (let EOF handle it at column 0)
2. Change yaml generation from `yamlencode()` to manual `join()` with proper 4-space indentation

New output:
```yaml
dnsNames:
    - "example.com"
    - "*.example.com"
```

## Files Changed

- `1.bootstrap/locals.tf`: Change `base_cert_domains_yaml` / `internal_cert_domains_yaml` generation
- `1.bootstrap/3.dns_and_cert.tf`: Remove heredoc indentation for Certificate YAML