### PR TITLE
BRN-008: Infrastructure SSOT Refactor - Design Document

### DIFF
--- a/docs/project/BRN-008.md
+++ b/docs/project/BRN-008.md
@@ -215,11 +215,44 @@ docs/
 
 | L1 服务 | 密钥管理 | 认证方式 | 原因 |
 |---------|----------|----------|------|
-| **Atlantis** | GitHub Secret | **Basic Auth** | 无法用 L2 Casdoor 保护 L1 服务 |
+| **Atlantis** | GitHub Secret | **Basic Auth + IP 白名单** | 无法用 L2 Casdoor 保护 L1 服务 |
 | **K3s API** | kubeconfig | Token | 系统层面 |
 | **Platform PG** | GitHub Secret | 内部访问 | 无需 Portal |
 
----
+### 3.2.3 高风险服务安全加固（P0）
+
+> ⚠️ **必须在 BRN-008 执行期间完成**
+
+#### Atlantis 安全加固
+
+**攻击面**：Atlantis 拥有所有 TF_VAR_*（包含 SSH Key、R2 Key、PG 密码）+ ClusterAdmin 权限
+
+**加固措施**：
+1. **Ingress IP 白名单**：限制仅 GitHub Webhook IP 段可访问
+   ```yaml
+   # Ingress annotation
+   nginx.ingress.kubernetes.io/whitelist-source-range: "140.82.112.0/20,185.199.108.0/22,192.30.252.0/22"
+   ```
+2. **启用 atlantis.yaml 严格模式**：
+   ```yaml
+   allowed_overrides: []  # 禁止 PR 覆盖 workflow
+   apply_requirements: [approved, mergeable]  # 必须审批后才能 apply
+   ```
+
+#### Vault 安全加固
+
+**风险**：当前 Vault 未开启审计日志，无法追溯操作
+
+**加固措施**：
+1. **启用审计日志**：
+   ```hcl
+   # 2.platform/2.secret.tf 修改
+   auditStorage = {
+     enabled = true
+     size    = "1Gi"
+   }
+   ```
+2. **Root Token 使用后 revoke**：日常管理使用普通 Token
 
 ### 3.3 `secrets.md` — 密钥分层与管理
 
@@ -735,11 +768,17 @@ PR Created → terraform-plan.yml (fmt, lint, plan)
 | 项目 | 描述 | 优先级 |
 |------|------|--------|
 | **Platform PG 部署** | L1 部署 PostgreSQL，Vault 迁移到 PG backend | **P0** |
+| **Atlantis IP 白名单** | Ingress 限制 GitHub Webhook IP 段 | **P0** |
+| **Vault 审计日志** | 启用 auditStorage，记录所有操作 | **P0** |
 | **Casdoor 部署** | 统一 SSO | P1 |
 | **Vault Agent 集成** | 应用层无密码 | P1 |
+| **NetworkPolicy** | data/platform 命名空间网络隔离 | P1 |
+| **R2 Bucket ACL** | 仅允许 Atlantis IP 访问 TF State | P1 |
 | **MkDocs 集成** | 自动生成文档站点 | P2 |
+| **Cloudflare Rate Limiting** | 关键路径防暴破 | P2 |
 | **密钥轮换自动化** | Vault Dynamic Secrets | P3 |
 | **Vault HA 部署** | 多副本 + PostgreSQL 主从 | P3 |
+| **Vault Auto-Unseal** | 使用 KMS 自动解封，避免人工持有 Key | P3 |
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds the design document for BRN-008: Infrastructure SSOT Refactor.

### Key Changes
- Added `docs/project/BRN-008.md` - comprehensive design document for refactoring docs to SSOT structure

### Design Goals
1. Refactor `docs/` to `docs/ssot/` with topic-based documentation (variables, secrets, pipelines, databases)
2. Restructure AGENTS.md into Components/Capabilities/Procedures sections
3. Deploy Platform PostgreSQL as Trust Anchor (L1)
4. Migrate Vault from Raft to PostgreSQL backend

### Next Steps
After this design is approved, implementation will begin with:
- P0: Platform PG deployment + Vault migration
- P0: Atlantis security hardening (IP whitelist)
- P0: Vault audit logging

Relates to: #BRN-008