### PR TITLE
fix: import existing platform namespace in L1

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -10,7 +10,14 @@
 # - Vault (L2): storage backend
 # - Casdoor (L2, future): user/session data
 
-# Create platform namespace in L1 (before L2 Vault deployment)
+# Import existing platform namespace (created by L2 previously)
+# This block only runs if the namespace exists but is not in L1 state yet
+import {
+  to = kubernetes_namespace.platform
+  id = "platform"
+}
+
+# Create/manage platform namespace in L1 (before L2 Vault deployment)
 resource "kubernetes_namespace" "platform" {
   metadata {
     name = "platform"


### PR DESCRIPTION
## Problem

PR #120 merged but deploy-k3s CI failed with:
```
Error: namespaces "platform" already exists
```

## Root Cause

The `platform` namespace was previously created by L2 and exists in cluster, but L1 (the new owner) tries to create it fresh.

## Solution

Add Terraform `import` block (TF 1.5+) to `5.platform_pg.tf`. This imports the existing namespace into L1 state on first apply.

```hcl
import {
  to = kubernetes_namespace.platform
  id = "platform"
}
```

After this fix, L1 owns the namespace and L2 uses `data.kubernetes_namespace.platform`.

Fixes: https://github.com/wangzitian0/infra/actions/runs/20140249950