### PR TITLE
docs: add k3s/kubero SSOT documentation

### DIFF
--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -9,6 +9,7 @@
 | 文件 | 核心问题 | 关键内容 |
 |------|----------|----------|
 | [dir.md](./dir.md) | 项目结构 | 目录树、Layer 定义、Namespace 注册 |
+| [k3s.md](./k3s.md) | 集群与 PaaS | K3s、StorageClass、Kubero、Namespace 规范 |
 | [vars.md](./vars.md) | 非密钥变量 | TF_VAR 列表、默认值、Feature Flags |
 | [secrets.md](./secrets.md) | 密钥管理 | 四层模型、1Password 清单、Vault Path |
 | [pipeline.md](./pipeline.md) | 流程汇总 | L1 手动 vs L2+ GitOps、灾备 |

--- a/docs/ssot/k3s.md
+++ b/docs/ssot/k3s.md
@@ -1,0 +1,74 @@
+# K3s 与 Kubero SSOT
+
+> **核心问题**：集群和 PaaS 平台如何管理？
+
+## K3s 集群架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  L1 Bootstrap - K3s Cluster                                 │
+├─────────────────────────────────────────────────────────────┤
+│  组件：                                                      │
+│  • K3s Server (单节点)                                       │
+│  • Traefik Ingress Controller (内置)                         │
+│  • cert-manager (Let's Encrypt)                              │
+│  • local-path-provisioner (存储)                             │
+├─────────────────────────────────────────────────────────────┤
+│  配置来源：                                                   │
+│  • VPS_HOST: GitHub Secret                                   │
+│  • VPS_SSH_KEY: GitHub Secret                                │
+│  • KUBECONFIG: L1 output → Atlantis 环境变量                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 服务矩阵
+
+| 组件 | 层级 | 职责 | 配置文件 |
+|------|------|------|----------|
+| **K3s** | L1 | Kubernetes 运行时 | `1.bootstrap/1.k3s.tf` |
+| **Traefik** | L1 | Ingress/负载均衡 | K3s 内置 |
+| **cert-manager** | L1 | TLS 证书自动化 | `1.bootstrap/3.dns_and_cert.tf` |
+| **local-path** | L1 | 持久化存储 | `1.bootstrap/4.storage.tf` |
+| **Kubero** | L2 | PaaS 平台 | `2.platform/4.kubero.tf` |
+
+## StorageClass 规范
+
+| StorageClass | 用途 | 保留策略 | 用于 |
+|--------------|------|----------|------|
+| `local-path` | 临时数据 | Delete | 无状态服务 |
+| `local-path-retain` | 持久数据 | Retain | 数据库、Vault |
+
+## Kubero PaaS
+
+Kubero 是 L2 平台的 PaaS 组件，用于部署应用：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  L2 Platform - Kubero                                        │
+├─────────────────────────────────────────────────────────────┤
+│  命名空间: kubero, kubero-operator-system                    │
+│  访问: https://kcloud.<internal_domain>                      │
+│  功能:                                                       │
+│  • Git-push 部署                                             │
+│  • 环境管理 (staging/prod)                                   │
+│  • 自动扩缩容                                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Namespace 规范
+
+| Namespace | 层级 | 用途 |
+|-----------|------|------|
+| `kube-system` | L1 | K3s 核心组件 |
+| `bootstrap` | L1 | Atlantis |
+| `platform` | L2 | Vault, Dashboard, OAuth2-Proxy, Platform PG |
+| `kubero` | L2 | Kubero UI |
+| `kubero-operator-system` | L2 | Kubero Operator |
+| `data` | L3 | 业务数据库 |
+| `apps` | L4 | 业务应用 |
+
+## 相关文件
+
+- K3s: [`1.bootstrap/1.k3s.tf`](../../1.bootstrap/1.k3s.tf)
+- 存储: [`1.bootstrap/4.storage.tf`](../../1.bootstrap/4.storage.tf)
+- Kubero: [`2.platform/4.kubero.tf`](../../2.platform/4.kubero.tf)


### PR DESCRIPTION
## Summary

Add missing SSOT documentation for k3s and kubero.

### Changes

- **[NEW]** `docs/ssot/k3s.md` - K3s cluster and Kubero PaaS documentation
  - K3s cluster architecture
  - StorageClass specifications (`local-path` vs `local-path-retain`)  
  - Kubero PaaS configuration
  - Namespace conventions table

- **[MODIFY]** `docs/ssot/README.md` - Added k3s.md to index table

Closes: Missing k3s/kubero SSOT documentation noted during BRN-008 review