### PR TITLE
fix: update PostgreSQL chart to version 16.3.2

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -33,7 +33,7 @@ resource "helm_release" "platform_pg" {
   namespace        = kubernetes_namespace.platform.metadata[0].name
   repository       = "https://charts.bitnami.com/bitnami"
   chart            = "postgresql"
-  version          = "16.3.3"
+  version          = "16.3.2"
   create_namespace = false
   timeout          = 600
 


### PR DESCRIPTION
Chart version 16.3.3 doesn't exist. Using 16.3.2 which is the latest available.

Fixes CI failure: https://github.com/wangzitian0/infra/actions/runs/20140690336