### PR TITLE
fix: add TODO comment to import block per Claude review

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -12,6 +12,7 @@
 
 # Import existing platform namespace (created by L2 previously)
 # This block only runs if the namespace exists but is not in L1 state yet
+# TODO: Remove this import block after first successful apply (namespace will be in L1 state)
 import {
   to = kubernetes_namespace.platform
   id = "platform"


### PR DESCRIPTION
Addresses Claude review comment on PR #122:
- Add TODO comment for post-apply cleanup of import block

Also triggers fresh deploy-k3s run with chart version 16.3.2 fix from PR #124.