### PR TITLE
fix: remove import block to allow platform namespace recreation

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -10,13 +10,7 @@
 # - Vault (L2): storage backend
 # - Casdoor (L2, future): user/session data
 
-# Import existing platform namespace (created by L2 previously)
-# This block only runs if the namespace exists but is not in L1 state yet
-# TODO: Remove this import block after first successful apply (namespace will be in L1 state)
-import {
-  to = kubernetes_namespace.platform
-  id = "platform"
-}
+
 
 # Create/manage platform namespace in L1 (before L2 Vault deployment)
 resource "kubernetes_namespace" "platform" {


### PR DESCRIPTION
## Summary

Removes the `import` block from `1.bootstrap/5.platform_pg.tf`.

### Context

1. PR #125 Atlantis Apply destroyed the `platform` namespace (as expected during handoff).
2. PR #126 Post-Merge CI failed because it tried to import a non-existent namespace.
3. This PR removes the import so Terraform can **recreate** the namespace fresh, allowing Platform PG deployment to proceed.

Fixes main branch deploy-k3s failure.