### PR TITLE
fix: use OCI registry for bitnami postgresql chart

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -26,7 +26,7 @@ resource "kubernetes_namespace" "platform" {
 resource "helm_release" "platform_pg" {
   name             = "postgresql"
   namespace        = kubernetes_namespace.platform.metadata[0].name
-  repository       = "https://charts.bitnami.com/bitnami"
+  repository       = "oci://registry-1.docker.io/bitnamicharts"
   chart            = "postgresql"
   version          = "16.3.2"
   create_namespace = false


### PR DESCRIPTION
## Summary

Fixes L1 Deployment failure due to 'invalid tag' error.

### Fix
- Updates repository in 5.platform_pg.tf to oci://registry-1.docker.io/bitnamicharts to support modern Bitnami OCI charts.