### PR TITLE
fix: pin postgresql image tag to 16.1.0-debian-12-r10

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -34,6 +34,9 @@ resource "helm_release" "platform_pg" {
 
   values = [
     yamlencode({
+      image = {
+        tag = "16.1.0-debian-12-r10"
+      }
       auth = {
         postgresPassword = var.vault_postgres_password
         database         = "vault"

--- a/1.bootstrap/README.md
+++ b/1.bootstrap/README.md
@@ -19,6 +19,7 @@ Managed by **GitHub Actions only** (not Atlantis).
 | `1.k3s.tf` | K3s Cluster | SSH-based VPS bootstrap |
 | `2.atlantis.tf` | Atlantis | GitOps CI/CD for L2-L4 |
 | `3.dns_and_cert.tf` | DNS + Certs | Cloudflare + cert-manager |
+| `5.platform_pg.tf` | Platform PostgreSQL | Trust anchor DB for Vault/Casdoor |
 
 ## Key Files
 
@@ -55,4 +56,4 @@ terraform apply
 | `r2_account_id` | R2 endpoint |
 
 ---
-*Last updated: 2025-12-10*
+*Last updated: 2025-12-12*


### PR DESCRIPTION
## Summary
- Pins `image.tag` to `16.1.0-debian-12-r10` in `5.platform_pg.tf`

Fixes L1 deployment failure (ImagePullBackOff) by pinning a valid bitnami/postgresql image tag.

> **Note**: This replaces #131 which had a corrupted `repository` URL.

## Test plan
- [ ] Atlantis plan shows only image tag change
- [ ] Apply succeeds and pod pulls the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)