### PR TITLE
HOTFIX: fix PostgreSQL startup failure

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -46,25 +46,8 @@ resource "helm_release" "platform_pg" {
         database         = "vault"
       }
       primary = {
-        # Initialize databases on first startup (IaC pattern - no null_resource needed)
-        initdb = {
-          scripts = {
-            "00-create-databases.sql" = <<-SQL
-              -- Create Casdoor database if not exists (using PL/pgSQL for idempotency)
-              DO $$
-              BEGIN
-                IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'casdoor') THEN
-                  CREATE DATABASE casdoor;
-                END IF;
-              END
-              $$;
-              
-              -- Grant permissions
-              GRANT ALL PRIVILEGES ON DATABASE vault TO postgres;
-              GRANT ALL PRIVILEGES ON DATABASE casdoor TO postgres;
-            SQL
-          }
-        }
+        # NOTE: Additional databases (casdoor) are created by null_resource.casdoor_database
+        # initdb.scripts cannot use CREATE DATABASE (runs inside transaction context)
         persistence = {
           enabled      = true
           storageClass = "local-path-retain"


### PR DESCRIPTION
## 🚨 Emergency Fix

**Symptom**: PostgreSQL pod stuck at 0/1 ready, never starts

**Root Cause**: PR #139 introduced `initdb.scripts` with `CREATE DATABASE` inside a `DO $$` block.

PostgreSQL runs initdb scripts inside a transaction context. `CREATE DATABASE` is a DDL statement that **cannot execute inside a transaction block**.

**Error in PostgreSQL logs**:
```
ERROR: CREATE DATABASE cannot run inside a transaction block
```

**Fix**: Remove the broken `initdb.scripts` block. Database creation is handled by `null_resource.casdoor_database` which runs after PostgreSQL is healthy.