### PR TITLE
fix: downgrade Casdoor to v1.570.0

### DIFF
--- a/2.platform/5.casdoor.tf
+++ b/2.platform/5.casdoor.tf
@@ -94,7 +94,7 @@ resource "helm_release" "casdoor" {
   name             = "casdoor"
   repository       = "oci://registry-1.docker.io/casbin"
   chart            = "casdoor-helm-charts"
-  version          = "v1.702.0"
+  version          = "v1.570.0"
   namespace        = data.kubernetes_namespace.platform.metadata[0].name
   create_namespace = false
   timeout          = 120
@@ -107,7 +107,7 @@ resource "helm_release" "casdoor" {
       image = {
         repository = "casbin"
         name       = "casdoor"
-        tag        = "v1.702.0"
+        tag        = "v1.570.0"
         pullPolicy = "IfNotPresent"
       }
 


### PR DESCRIPTION
## Fix Casdoor Login Bug

v1.702.0 has known 'unexpected end of JSON input' bug on login.
Downgrading to v1.570.0 which is reported stable by community.

References:
- GitHub issue #876, #901, #2213, #3224

Changes:
- Helm chart version: v1.702.0 → v1.570.0  
- Image tag: v1.702.0 → v1.570.0