### PR TITLE
docs: address PR #125-135 review comments

### DIFF
--- a/0.check_now.md
+++ b/0.check_now.md
@@ -1,40 +1,52 @@
 # 0.check_now.md
 
 ## 1. What (Target)
-BRN-008: IaC Initialization Patterns for PostgreSQL and Casdoor SSO.
+BRN-008 P2: Casdoor SSO Login Fix and One-Auth Gate Implementation.
 
 ## 2. Why (Value)
-Implement declarative IaC initialization patterns to eliminate manual setup and `null_resource` hacks.
+Complete SSO integration with Casdoor login bugfix (`copyrequestbody=true`) and implement One-Auth gate for L2 services.
 
 ## 3. Where (Location)
-- L1 Bootstrap: `1.bootstrap/5.platform_pg.tf` (initdb.scripts for DB creation)
-- L2 Platform: `2.platform/5.casdoor.tf` (initData for org/user/app)
-- Docs: `docs/ssot/secrets.md`, `docs/ssot/auth.md`
+- L2 Platform: `2.platform/5.casdoor.tf` (copyrequestbody fix, initDataFile config)
+- L2 Platform: `2.platform/99.one-auth.tf` (SSO gate switch)
+- L1 Bootstrap: `1.bootstrap/5.platform_pg.tf` (timeout reduction)
+- Docs: `2.platform/README.md` (One-Auth documentation)
 
 ## 4. Who (Owner)
 Infra Team / AI Assistant (Antigravity)
 
 ## 5. When (Timeline)
-Current Phase: PR #139 Review
+Current Phase: Casdoor Deployment Verification
 
 ## 6. How (Action Plan)
 
 ### Blocking Actions
-- [ ] **Merge PR #139**: IaC initialization patterns
-  - [PR Link](https://github.com/wangzitian0/infra/pull/139)
-  - Changes: initdb.scripts, initData, random_password, SSOT docs
+- [ ] **Deploy Casdoor with copyrequestbody fix**: Apply latest main to cluster
+- [ ] **Verify Casdoor Login**: Login with admin/123 at sso.zitian.party
 
-### Completed
-- [x] PostgreSQL: Added `initdb.scripts` for automatic database creation
-- [x] Casdoor: Added `initData` for organization/user/app initialization
-- [x] Removed `null_resource.casdoor_database` (replaced by initdb.scripts)
-- [x] Fixed hardcoded password with `random_password` resource
-- [x] Updated `docs/ssot/secrets.md` with 1Password→GitHub mappings
-- [x] Updated `docs/ssot/auth.md` with layered auth model
-- [x] Synced `VAULT_POSTGRES_PASSWORD` to GitHub Secrets
-- [x] Imported all secrets to 1Password as SSOT
+### Completed (PRs #125-147)
+- [x] PR #125: Vault PostgreSQL migration (Raft → PostgreSQL storage)
+- [x] PR #130: Bitnami OCI registry fix
+- [x] PR #132: PostgreSQL image tag pinning
+- [x] PR #133: Atlantis probe interval reduction (60s → 10s)
+- [x] PR #134: Vault PostgreSQL schema provisioning
+- [x] PR #144: Casdoor init_data.json via extraVolumes + initDataFile config
+- [x] PR #144: Helm timeout reduction (300s → 120s)
+- [x] Casdoor login bug root cause identified: missing `copyrequestbody=true` in app.conf
+- [x] One-Auth gate implementation (`enable_one_auth` variable)
+- [x] Updated docs/ssot/secrets.md with 1Password→GitHub mappings
+- [x] Updated docs/ssot/auth.md with layered auth model
 
-## Verification
-- [ ] All CI checks pass (GitGuardian, Atlantis plan/apply)
-- [ ] Casdoor pod starts with correct database connection
-- [ ] Admin login works (password from `terraform output -raw casdoor_admin_password`)
+### Known Issues
+- Casdoor v1.702.0 and v1.570.0 both have init_data.json loading issues
+- `init_data.json` password is NOT loaded if DB already has default admin/123 user
+- Manual DB recreation required after Casdoor deployment changes
+
+## Verification Checklist
+- [ ] Casdoor pod running (1/1)
+- [ ] Admin login works at https://sso.zitian.party (admin/123)
+- [ ] OAuth2-Proxy running (prerequisite for One-Auth gate)
+- [ ] One-Auth gate can be enabled after SSO verification
+
+---
+*Last updated: 2025-12-13*

--- a/1.bootstrap/README.md
+++ b/1.bootstrap/README.md
@@ -55,5 +55,11 @@ terraform apply
 | `r2_bucket` | State bucket name |
 | `r2_account_id` | R2 endpoint |
 
+## Chart Repository Migration
+
+- **PostgreSQL Chart**: Migrated to OCI format (`oci://registry-1.docker.io/bitnamicharts`) as of 2025-12-11
+- **Reason**: Bitnami deprecated HTTP chart repository in favor of OCI registry
+- **Image Pin**: `16.1.0-debian-12-r10` (explicit tag to avoid ImagePullBackOff)
+
 ---
-*Last updated: 2025-12-12*
+*Last updated: 2025-12-13*


### PR DESCRIPTION
## Summary
Addresses documentation guard violations identified in code reviews for PRs #125-135.

## Changes

### 0.check_now.md
- Updated to reflect current state (PRs #125-147)
- Reflects Casdoor `copyrequestbody=true` fix for login bug
- Documents One-Auth gate implementation and `enable_one_auth` variable
- Lists known issues (init_data.json loading, version bugs)
- Updated verification checklist

### 1.bootstrap/README.md
- Added **Chart Repository Migration** section (per PR #130 review)
- Documented Bitnami OCI registry migration (2025-12-11)
- Added PostgreSQL image pin info (`16.1.0-debian-12-r10`)

## Review Comments Addressed
- PR #125: Missing 0.check_now.md update
- PR #130: Missing 1.bootstrap/README.md OCI documentation
- PR #132: Missing 0.check_now.md update
- PR #133: Missing documentation updates
- PR #134: Missing 0.check_now.md and change log updates

## Side Effect
This PR will trigger Atlantis plan but no infrastructure changes (docs only).