### PR TITLE
chore: trigger Casdoor deployment

### DIFF
--- a/0.check_now.md
+++ b/0.check_now.md
@@ -50,3 +50,4 @@ Current Phase: Casdoor Deployment Verification
 
 ---
 *Last updated: 2025-12-13*
+# Trigger deployment 20251213053527


### PR DESCRIPTION
## Purpose
Trigger Atlantis to recreate Casdoor Helm release.

## Issue
- Casdoor Helm release was deleted during debugging
- Ingress still exists but backend (pod) doesn't → 502/504 errors
- Need Atlantis apply to recreate the deployment

## Expected Result
- Casdoor pod created with `copyrequestbody=true` config
- Login at https://sso.zitian.party should work with admin/123