### PR TITLE
chore: deploy Casdoor with correct config

### DIFF
--- a/2.platform/5.casdoor.tf
+++ b/2.platform/5.casdoor.tf
@@ -261,3 +261,5 @@ output "casdoor_admin_password" {
   description = "Casdoor admin password (retrieve with: terraform output -raw casdoor_admin_password)"
   sensitive   = true
 }
+
+# TRIGGER_DEPLOYMENT: Force CI to run terraform plan/apply


### PR DESCRIPTION
## Issue
Casdoor deployment is broken:
- Helm release was manually uninstalled/reinstalled with minimal config
- Pod in CrashLoopBackOff due to missing PostgreSQL configuration

## Fix
Trigger Terraform apply to deploy Casdoor with complete configuration:
- `copyrequestbody=true` (fixes login JSON parse bug)
- PostgreSQL dataSourceName (fixes DB connection)
- initDataFile path (for init_data.json)
- Correct ingress configuration