### PR TITLE
fix: revert PostgreSQL to Bitnami image

### DIFF
--- a/1.bootstrap/5.platform_pg.tf
+++ b/1.bootstrap/5.platform_pg.tf
@@ -20,7 +20,8 @@ resource "kubernetes_namespace" "platform" {
   }
 }
 
-# Platform PostgreSQL via Bitnami Helm chart (with official postgres image)
+# Platform PostgreSQL via Bitnami Helm chart
+# Note: Bitnami deletes old image tags, so we use 'latest' with IfNotPresent
 resource "helm_release" "platform_pg" {
   name             = "postgresql"
   namespace        = kubernetes_namespace.platform.metadata[0].name
@@ -34,11 +35,9 @@ resource "helm_release" "platform_pg" {
 
   values = [
     yamlencode({
-      # Use official postgres image (Bitnami deletes old tags, official doesn't)
+      # Bitnami deletes old tags; use latest + IfNotPresent to reduce drift
       image = {
-        registry   = "docker.io"
-        repository = "postgres"
-        tag        = "17.2-alpine"
+        tag        = "latest"
         pullPolicy = "IfNotPresent"
       }
       auth = {


### PR DESCRIPTION
## Problem

Official postgres image 与 Bitnami chart 不兼容：
```
could not access "/bitnami/postgresql/data/postgresql.conf": No such file or directory
```

## Solution

回滚到 Bitnami 镜像：
```hcl
image = {
  tag        = "latest"
  pullPolicy = "IfNotPresent"
}
```

## Trade-off

| 方案 | 可复现性 | 可用性 |
|------|---------|-------|
| Bitnami 固定 tag | ❌ 被删除 | ❌ |
| Official image | ✅ | ❌ 不兼容 |
| **Bitnami latest + IfNotPresent** | ⚠️ | ✅ |

`IfNotPresent` 确保节点上已有镜像时不重新拉取，减少 drift。