### PR TITLE
hotfix: pass vault_root_token to L2 setup

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -149,6 +149,8 @@ jobs:
           # OAuth2-Proxy (GitHub OAuth for Dashboard protection)
           github_oauth_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           github_oauth_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          # L2/L3: Vault Access
+          vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
 
       - name: Terraform plan (L2)
         working-directory: 2.platform


### PR DESCRIPTION
## Problem
L2 Apply failed with 'no vault token set on Client' error.

```
Error: no vault token set on Client
  with vault_mount.kv,
  on 6.vault-database.tf line 14
```

## Root Cause
TF_VAR_vault_root_token was only passed to L1 setup, not L2 setup in deploy-k3s.yml.

L2 now has Vault provider (for vault_mount resources) and needs the token.

## Fix
Added vault_root_token to L2 Setup Terraform Environment in deploy-k3s.yml.