### PR TITLE
fix: port-forward Vault for L2 in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -152,10 +152,20 @@ jobs:
           # L2/L3: Vault Access
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
 
+      # Port-forward Vault for L2 Terraform (runner is outside cluster, can't use internal DNS)
+      - name: Port-forward Vault
+        env:
+          KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
+        run: |
+          kubectl port-forward svc/vault -n platform 8200:8200 &
+          sleep 3
+          echo "VAULT_PORT_FORWARD_PID=$!" >> $GITHUB_ENV
+
       - name: Terraform plan (L2)
         working-directory: 2.platform
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
+          TF_VAR_vault_address: "http://localhost:8200"
         run: terraform plan -input=false
 
       - name: Apply Infrastructure (L2)
@@ -163,6 +173,7 @@ jobs:
         working-directory: 2.platform
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
+          TF_VAR_vault_address: "http://localhost:8200"
           TF_LOG: INFO
         run: |
           terraform apply -auto-approve || {

--- a/2.platform/providers.tf
+++ b/2.platform/providers.tf
@@ -28,7 +28,7 @@ provider "cloudflare" {
 # Vault provider for database secrets engine configuration
 # Uses root token for now; can migrate to Kubernetes auth later
 provider "vault" {
-  address         = "http://vault.platform.svc.cluster.local:8200"
+  address         = var.vault_address
   token           = var.vault_root_token
   skip_tls_verify = true
 }

--- a/2.platform/variables.tf
+++ b/2.platform/variables.tf
@@ -153,6 +153,12 @@ variable "vault_root_token" {
   default     = ""
 }
 
+variable "vault_address" {
+  description = "Vault server address. Default is internal K8s DNS for Atlantis. Set to http://localhost:8200 for GitHub Actions with port-forward."
+  type        = string
+  default     = "http://vault.platform.svc.cluster.local:8200"
+}
+
 # ============================================================
 # One-Auth (SSO Gate Switch)
 # ============================================================


### PR DESCRIPTION
## Problem
L2 Apply failed with DNS resolution error:
```
dial tcp: lookup vault.platform.svc.cluster.local on 127.0.0.53:53: server misbehaving
```

GitHub Actions runner is outside K8s cluster, cannot resolve internal service DNS.

## Fix
1. Added `vault_address` variable to L2 (default: internal DNS for Atlantis)
2. Added kubectl port-forward step before L2 plan/apply
3. Set `TF_VAR_vault_address=http://localhost:8200` in CI environment

## Result
- **Atlantis (in-cluster)**: Uses default internal DNS
- **GitHub Actions**: Uses port-forward to localhost:8200