### PR TITLE
fix: remove re-init from apply steps to prevent state lineage mismatch

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -123,16 +123,7 @@ workflows:
         - plan
     apply:
       steps:
-        - run: rm -rf .terraform
-        - run: |
-            cat > backend.tfvars <<EOF
-            bucket    = "${R2_BUCKET}"
-            key       = "k3s/data-${WORKSPACE}.tfstate"
-            endpoints = { s3 = "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" }
-            EOF
-        # Note: TF_VAR_vault_root_token is already in Atlantis Pod env (from L1 Helm)
-        - init:
-            extra_args: ["-backend-config=backend.tfvars"]
+        # Reuse .terraform from plan step to avoid state lineage mismatch
         - apply
 
   # L4: Apps
@@ -151,13 +142,5 @@ workflows:
         - plan
     apply:
       steps:
-        - run: rm -rf .terraform
-        - run: |
-            cat > backend.tfvars <<EOF
-            bucket    = "${R2_BUCKET}"
-            key       = "k3s/apps-${WORKSPACE}.tfstate"
-            endpoints = { s3 = "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" }
-            EOF
-        - init:
-            extra_args: ["-backend-config=backend.tfvars"]
+        # Reuse .terraform from plan step to avoid state lineage mismatch
         - apply


### PR DESCRIPTION
## Problem
L3/L4 Atlantis apply was failing with:
```
Error: Saved plan does not match the given state
The given plan file can not be applied because it was created from a different state lineage.
```

## Root Cause
Apply steps were doing `rm -rf .terraform` + re-init, creating a new state lineage different from plan file.

## Fix
Simplified apply steps to only contain `apply` command, reusing plan's .terraform directory.

## Before/After
```diff
 apply:
   steps:
-    - run: rm -rf .terraform
-    - run: cat > backend.tfvars ...
-    - init
+    # Reuse .terraform from plan step
     - apply
```

This ensures consistent state lineage between plan and apply.