### PR TITLE
feat: enable portal SSO gate for Vault/Dashboard/Kubero

### DIFF
--- a/1.bootstrap/2.atlantis.tf
+++ b/1.bootstrap/2.atlantis.tf
@@ -60,6 +60,8 @@ resource "helm_release" "atlantis" {
           TF_VAR_github_oauth_client_secret = var.github_oauth_client_secret
           # Casdoor SSO
           TF_VAR_casdoor_admin_password = var.casdoor_admin_password
+          # Portal SSO Gate - enables OIDC apps for Vault/Dashboard/Kubero
+          TF_VAR_enable_portal_sso_gate = "true"
           # L3 Vault access
           TF_VAR_vault_root_token = var.vault_root_token
         }


### PR DESCRIPTION
## Summary
Enables Portal SSO Gate which creates OIDC applications in Casdoor:

| Application | Client ID | Purpose |
|-------------|-----------|---------|
| portal-gate | portal-gate | OAuth2-Proxy forward auth |
| vault-oidc | vault-oidc | Vault OIDC login |
| dashboard-oidc | dashboard-oidc | K8s Dashboard login |
| kubero-oidc | kubero-oidc | Kubero PaaS login |

## Changes
- Added `TF_VAR_enable_portal_sso_gate=true` to Atlantis environment

## Deployment
This requires L1 apply to update Atlantis Pod environment, then L2 apply to create the Casdoor applications.