### PR TITLE
fix: oauth2-proxy oidc-issuer-url argument

### DIFF
--- a/2.platform/1.portal-auth.tf
+++ b/2.platform/1.portal-auth.tf
@@ -64,7 +64,7 @@ resource "helm_release" "portal_auth" {
 
       extraArgs = {
         provider                    = "oidc"
-        oidc_issuer_url             = local.casdoor_issuer
+        "oidc-issuer-url"           = local.casdoor_issuer
         email-domain                = "*"
         cookie-domain               = ".${local.internal_domain}"
         cookie-secure               = "true"


### PR DESCRIPTION
## Bug

`portal-auth-oauth2-proxy` was `CrashLoopBackOff` with exit code 2.

## Root Cause

oauth2-proxy CLI uses **dashes** not underscores:
- ❌ `oidc_issuer_url`
- ✅ `oidc-issuer-url`

## Fix

Changed extraArgs key to use dashes.

## Affected Services

- https://secrets.zitian.party (Vault)
- https://kdashboard.zitian.party (Dashboard)
- https://kcloud.zitian.party (Kubero)

All behind Portal-Auth SSO gate.