### PR TITLE
fix: remove orphaned import block for portal_auth

### DIFF
--- a/2.platform/1.portal-auth.tf
+++ b/2.platform/1.portal-auth.tf
@@ -31,11 +31,6 @@ resource "random_password" "portal_cookie_secret" {
   special = false
 }
 
-import {
-  to = helm_release.portal_auth[0]
-  id = "platform/portal-auth"
-}
-
 resource "helm_release" "portal_auth" {
   count = local.portal_sso_gate_enabled ? 1 : 0
 


### PR DESCRIPTION
## Problem
When `enable_portal_sso_gate=false`, the `helm_release.portal_auth[0]` resource doesn't exist in config, but the unconditional import block still tries to import to this non-existent address.

This causes Terraform to fail with:
```
Error: Cannot import to non-existent resource address

Importing to resource address helm_release.portal_auth[0] is not possible,
because that address does not exist in configuration.
```

## Solution
Remove the orphaned import block. It was a one-time migration helper that is no longer needed.

## Impact
- Unblocks L2 Apply step in deploy-k3s workflow
- Enables L3 Data layer databases to be deployed