### PR TITLE
fix: use configurable vault_address in L3 provider

### DIFF
--- a/3.data/providers.tf
+++ b/3.data/providers.tf
@@ -18,11 +18,12 @@ provider "helm" {
 }
 
 # Vault provider for reading secrets
-# Address: internal K8s service DNS
+# Address: configurable to support both in-cluster (Atlantis) and port-forward (GitHub runner)
 provider "vault" {
-  address = "http://vault.platform.svc.cluster.local:8200"
+  address = var.vault_address
   token   = var.vault_root_token
 
   # Skip TLS verification for internal communication
   skip_tls_verify = true
 }
+

--- a/3.data/variables.tf
+++ b/3.data/variables.tf
@@ -6,6 +6,12 @@ variable "kubeconfig_path" {
   default     = ""
 }
 
+variable "vault_address" {
+  description = "Vault server address. Defaults to in-cluster DNS; override to http://localhost:8200 for port-forward."
+  type        = string
+  default     = "http://vault.platform.svc.cluster.local:8200"
+}
+
 variable "vault_root_token" {
   description = "Vault root token for reading secrets (from 1Password via GitHub Secret)"
   type        = string
@@ -17,3 +23,4 @@ variable "vault_root_token" {
     error_message = "vault_root_token must be a valid Vault token (or empty for plan-only)."
   }
 }
+


### PR DESCRIPTION
## Problem
L3 Vault provider was hardcoded to use internal K8s DNS (`vault.platform.svc.cluster.local`) which is not resolvable from GitHub Actions runner.

This caused L3 Apply to fail with:
```
dial tcp: lookup vault.platform.svc.cluster.local on 127.0.0.53:53: server misbehaving
```

## Solution
Added `vault_address` variable with in-cluster default, but overridable via `TF_VAR_vault_address` for port-forward from runner (same pattern as L2).

## Impact
- Unblocks L3 Data layer deployment
- Enables 4 databases (PostgreSQL, Redis, ClickHouse, ArangoDB) to be deployed