### PR TITLE
fix: add time_sleep for ArangoDB CRD availability

### DIFF
--- a/3.data/versions.tf
+++ b/3.data/versions.tf
@@ -14,5 +14,13 @@ terraform {
       source  = "hashicorp/vault"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9"
+    }
   }
 }


### PR DESCRIPTION
## Problem
ArangoDB operator Helm release completes before CRD is fully established, causing:
```
Error: API did not recognize GroupVersionKind from manifest (CRD may not be installed)
```

## Solution
Added 30s `time_sleep` after operator deployment to ensure CRD is available before attempting to create ArangoDeployment CR.

## Changes
- Added `time_sleep.wait_for_arangodb_crd` resource
- Updated `kubernetes_manifest.arangodb_deployment.depends_on` to use time_sleep
- Added `hashicorp/time` and `hashicorp/random` providers to versions.tf

## Impact
Unblocks L3 Data layer full deployment (4 databases)