### PR TITLE
fix: use kubectl_manifest for ArangoDB to avoid plan-time CRD validation

### DIFF
--- a/3.data/providers.tf
+++ b/3.data/providers.tf
@@ -1,6 +1,6 @@
 # L3 Data Layer Provider Configuration
 #
-# Providers: kubernetes, helm, vault
+# Providers: kubernetes, kubectl, helm, vault
 # Vault access: Uses root token from GitHub Secret (for initial setup)
 # Future: Migrate to Kubernetes auth method
 
@@ -8,6 +8,11 @@
 # Providers will auto-detect in-cluster ServiceAccount credentials.
 
 provider "kubernetes" {
+  config_path = var.kubeconfig_path != "" ? var.kubeconfig_path : null
+}
+
+# kubectl provider for CRD-based resources (avoids plan-time API validation)
+provider "kubectl" {
   config_path = var.kubeconfig_path != "" ? var.kubeconfig_path : null
 }
 
@@ -26,4 +31,3 @@ provider "vault" {
   # Skip TLS verification for internal communication
   skip_tls_verify = true
 }
-

--- a/3.data/versions.tf
+++ b/3.data/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
     helm = {
       source  = "hashicorp/helm"
       version = "~> 2.0"


### PR DESCRIPTION
## Problem
`kubernetes_manifest` validates CRD existence during Terraform **plan phase**, before the operator Helm release is applied. This causes:
```
Error: API did not recognize GroupVersionKind from manifest (CRD may not be installed)
no matches for kind "ArangoDeployment" in group "database.arangodb.com"
```

## Root Cause
The CRD isn't installed yet at plan time because ArangoDB operator hasn't been deployed. `time_sleep` only helps at apply time, not plan time.

## Solution
Changed to `kubectl_manifest` (alekc/kubectl provider) which doesn't perform plan-time API validation, allowing the operator to be deployed first before creating the ArangoDeployment CR.

## Changes
- Added `kubectl` provider to L3 versions.tf and providers.tf
- Converted `kubernetes_manifest.arangodb_deployment` to `kubectl_manifest.arangodb_deployment`

## Impact
Unblocks L3 Data layer full deployment (4 databases)