### PR TITLE
fix: remove ClickHouse extraOverrides that may cause startup failure

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -78,24 +78,8 @@ resource "helm_release" "clickhouse" {
           memory = "256Mi"
         }
       }
-      # Resource limits to prevent runaway queries
-      extraOverrides = <<-EOT
-        <profiles>
-          <default>
-            <max_memory_usage>800000000</max_memory_usage>
-            <max_execution_time>300</max_execution_time>
-            <max_concurrent_queries>10</max_concurrent_queries>
-          </default>
-        </profiles>
-        <quotas>
-          <default>
-            <interval>
-              <duration>3600</duration>
-              <queries>1000</queries>
-            </interval>
-          </default>
-        </quotas>
-      EOT
+      # Note: Custom profiles/quotas removed for MVP stability
+      # TODO: Add custom configs via usersFiles if needed per Bitnami docs
     })
   ]
 }


### PR DESCRIPTION
## Problem
ClickHouse pod stuck at 0/1 ready during entire 5-min Helm timeout, causing L3 Apply to fail with `context deadline exceeded`.

## Probable Cause
The `extraOverrides` XML config for profiles/quotas may be:
1. Malformed (embedded heredoc in yamlencode)
2. Incompatible with the Bitnami chart version

## Solution
Remove custom profiles/quotas config for MVP stability. Per Bitnami docs, use `usersFiles` instead of `extraOverrides` if custom configs are needed.

## Impact
Unblocks L3 Data layer deployment