### PR TITLE
fix: temporarily disable prevent_destroy on ClickHouse

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -39,7 +39,9 @@ resource "helm_release" "clickhouse" {
   wait_for_jobs    = true
 
   lifecycle {
-    prevent_destroy = true # Prevent accidental data loss
+    # Temporarily disabled to allow re-deployment after failed release
+    # TODO: Re-enable after initial deployment succeeds
+    prevent_destroy = false
 
     precondition {
       condition     = can(data.vault_kv_secret_v2.clickhouse.data["password"]) && length(data.vault_kv_secret_v2.clickhouse.data["password"]) >= 16


### PR DESCRIPTION
## Problem
Terraform fails with `Instance cannot be destroyed` because ClickHouse has `prevent_destroy = true` and the failed release needs to be cleaned up before re-deploying.

## Solution
Temporarily set `prevent_destroy = false` to allow Terraform to clean up and redeploy.

## TODO
Re-enable `prevent_destroy` after initial deployment succeeds.