### PR TITLE
fix: remove manual image tag override for ClickHouse

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -52,10 +52,8 @@ resource "helm_release" "clickhouse" {
   values = [
     yamlencode({
       # Bitnami deletes old tags; use latest + IfNotPresent to reduce drift
-      image = {
-        tag        = "latest"
-        pullPolicy = "IfNotPresent"
-      }
+      # Use chart default image tag (validated by Bitnami) to avoid ImagePullBackOff with 'latest'
+      # image node removed to fallback to values.yaml defaults
       auth = {
         username = "default"
         password = data.vault_kv_secret_v2.clickhouse.data["password"]


### PR DESCRIPTION
## Problem
ClickHouse pod failed to start with `ImagePullBackOff`.
Diagnosis revealed `Back-off pulling image "docker.io/bitnami/clickhouse:latest"`.
Using `latest` tag is unstable and can break when upstream registry changes or strict pull policies are enforced.

## Solution
Remove the manual `tag = "latest"` override in Terraform.
This allows the Helm chart to use its default, version-locked image tag (e.g., `24.7.3-debian-12-r1`), ensuring compatibility and availability.

## Verification
CI run should pass with ClickHouse pod successfully pulling image and starting.