### PR TITLE
fix: use rolling image tag for ClickHouse

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -51,9 +51,10 @@ resource "helm_release" "clickhouse" {
 
   values = [
     yamlencode({
-      # Bitnami deletes old tags; use latest + IfNotPresent to reduce drift
-      # Use chart default image tag (validated by Bitnami) to avoid ImagePullBackOff with 'latest'
-      # image node removed to fallback to values.yaml defaults
+      image = {
+        tag        = "24.7.3-debian-12" # Rolling tag to avoid ImagePullBackOff on specific deleted revisions (e.g. r0)
+        pullPolicy = "IfNotPresent"
+      }
       auth = {
         username = "default"
         password = data.vault_kv_secret_v2.clickhouse.data["password"]


### PR DESCRIPTION
## Problem
ClickHouse deployment failed with `ImagePullBackOff` because the default revision tag `24.7.3-debian-12-r0` is missing.

## Solution
Explicitly set the image tag to `24.7.3-debian-12`. This is the rolling tag that always points to the latest revision of the version, ensuring the image can be pulled.

## Verification
Confirm via CI that `clickhouse-shard0-0` pod transitions from `ImagePullBackOff` to `Running`.