### PR TITLE
fix: update ClickHouse image tag to 24.8.5-debian-12

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -52,7 +52,7 @@ resource "helm_release" "clickhouse" {
   values = [
     yamlencode({
       image = {
-        tag        = "24.7.3-debian-12" # Rolling tag to avoid ImagePullBackOff on specific deleted revisions (e.g. r0)
+        tag        = "24.8.5-debian-12" # Validated existing tag to resolve ImagePullBackOff
         pullPolicy = "IfNotPresent"
       }
       auth = {


### PR DESCRIPTION
## Problem
ClickHouse deployment failed with `ImagePullBackOff` because previous tags (`latest`, `24.7.3-debian-12`) were unavailable or deprecated in the upstream Bitnami registry.

## Solution
Explicitly set the image tag to `24.8.5-debian-12`.
This is a verified, existing tag that corresponds to a stable version of ClickHouse.

## Verification
Confirm via CI that `clickhouse-shard0-0` pod transitions from `ImagePullBackOff` to `Running`.