### PR TITLE
fix: upgrade ClickHouse Helm Chart to 9.4.4

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -32,7 +32,7 @@ resource "helm_release" "clickhouse" {
   namespace        = local.namespace_name # Per-env: data-staging, data-prod
   repository       = "oci://registry-1.docker.io/bitnamicharts"
   chart            = "clickhouse"
-  version          = "6.2.17"
+  version          = "9.4.4" # Upgraded from 6.2.17 to resolve image availability issues
   create_namespace = false
   timeout          = 300 # Consistent with PR #170 standard (was 600s)
   wait             = true
@@ -51,10 +51,7 @@ resource "helm_release" "clickhouse" {
 
   values = [
     yamlencode({
-      image = {
-        tag        = "24.8.5-debian-12" # Validated existing tag to resolve ImagePullBackOff
-        pullPolicy = "IfNotPresent"
-      }
+      # Removed manual image config to use chart defaults (verified valid images for chart 9.4.4)
       auth = {
         username = "default"
         password = data.vault_kv_secret_v2.clickhouse.data["password"]


### PR DESCRIPTION
## Problem
Deployment failed due to deprecated/missing images in the old Helm Chart version (6.2.17). Manual image tagging attempts failed because the old chart doesn't support modern standard tags.

## Solution
Upgrade the Bitnami ClickHouse Helm Chart from `6.2.17` to `9.4.4`.
This allows using the chart's valid default images (e.g., ClickHouse 25.x).

## Verification
Confirm `clickhouse-shard0-0` transitions to `Running`.