### PR TITLE
fix(ci): infra-flash-update workflow permissions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -88,6 +88,7 @@ Atlantis 评论 "Ran Plan for..."
 - 通过 `<!-- infra-flash-commit:abc1234 -->` 锚点定位评论
 - 自动附带触发者评论 & Atlantis 输出链接
 - 成功时追加下一步（Plan → Apply → Merge），失败则指向修复操作
+- 权限：需要 `issues: write`（更新评论）与 `pull-requests: write`（读取 PR 信息）
 
 ---
 

--- a/.github/workflows/infra-flash-update.yml
+++ b/.github/workflows/infra-flash-update.yml
@@ -14,6 +14,8 @@ jobs:
        contains(github.event.comment.body, 'Ran Apply'))
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Fix: `infra-flash-update.yml` was not being scheduled on Atlantis `Ran Plan/Apply` comments (PR #193 repro).

Change:
- Add `contents: read` + `issues: write` permissions to `.github/workflows/infra-flash-update.yml` so the updater can run and update the per-commit infra-flash comment.
- Document required permissions in `.github/workflows/README.md`.

After merge:
- Re-run `atlantis plan -p platform` on PR #193 and confirm the per-commit infra-flash comment gets an `### Atlantis Plan ...` block appended.