### PR TITLE
fix: disable 'keeper' in ClickHouse Chart 9.4.4

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -59,7 +59,10 @@ resource "helm_release" "clickhouse" {
       shards       = 1 # Single VPS MVP: single shard (can scale later)
       replicaCount = 1 # Single VPS MVP: no replication (can scale later)
       zookeeper = {
-        enabled = false # Disable ZooKeeper for single-node setup
+        enabled = false # Disable external ZooKeeper
+      }
+      keeper = {
+        enabled = false # Disable bundled ClickHouse Keeper (new in chart 9.x) for single-node
       }
       persistence = {
         enabled      = true


### PR DESCRIPTION
## Problem
Chart 9.x enables `clickhouse-keeper` by default, which attempts to pull a specific image revision that is missing from Docker Hub (`25.7.5-debian-12-r0`), causing ImagePullBackOff.

## Solution
Explicitly disable `keeper` in `3.clickhouse.tf`.
We are deploying a single-node ClickHouse instance (MVP) and do not need Keeper/ZooKeeper replication coordination.

## Verification
Confirm `clickhouse-shard0-0` starts successfully without waiting for a non-existent Keeper pod.