### PR TITLE
fix: pin ClickHouse and Keeper image tags to 24.8.5-debian-12

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -51,7 +51,11 @@ resource "helm_release" "clickhouse" {
 
   values = [
     yamlencode({
-      # Removed manual image config to use chart defaults (verified valid images for chart 9.4.4)
+      # Pin both main and keeper images to avoid ImagePullBackOff
+      image = {
+        tag        = "24.8.5-debian-12" # Pin to valid rolling tag
+        pullPolicy = "IfNotPresent"
+      }
       auth = {
         username = "default"
         password = data.vault_kv_secret_v2.clickhouse.data["password"]
@@ -62,7 +66,11 @@ resource "helm_release" "clickhouse" {
         enabled = false # Disable external ZooKeeper
       }
       keeper = {
-        enabled = false # Disable bundled ClickHouse Keeper (new in chart 9.x) for single-node
+        enabled = true # Enable bundled ClickHouse Keeper
+        image = {
+          tag        = "24.8.5-debian-12" # Pin to valid rolling tag to avoid ImagePullBackOff
+          pullPolicy = "IfNotPresent"
+        }
       }
       persistence = {
         enabled      = true


### PR DESCRIPTION
## Problem
ClickHouse deployment failed due to ImagePullBackOff caused by:
1. Chart 6.2.17 using deprecated default image tags
2. Chart 9.4.4 default enabling `keeper` with missing image revision tag

## Solution
- Upgraded to Chart `9.4.4`
- Pinned main ClickHouse image: `24.8.5-debian-12`
- Pinned Keeper image: `24.8.5-debian-12`
- Enabled Keeper for consistency guarantees

## Image Verification
Both tags verified available via Docker Hub Registry V2 API.

## Verification
Confirm both `clickhouse-shard0-0` and `clickhouse-keeper-0` pods reach `Running` state.