### PR TITLE
fix: use 'latest' tag for clickhouse-keeper

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -68,7 +68,8 @@ resource "helm_release" "clickhouse" {
       keeper = {
         enabled = true # Enable bundled ClickHouse Keeper
         image = {
-          tag        = "24.8.5-debian-12" # Pin to valid rolling tag to avoid ImagePullBackOff
+          # Bitnami removed versioned tags after Aug 2025, only 'latest' available
+          tag        = "latest"
           pullPolicy = "IfNotPresent"
         }
       }


### PR DESCRIPTION
## Problem
`bitnami/clickhouse-keeper:24.8.5-debian-12` does not exist.
Bitnami removed versioned tags after Aug 2025, only `latest` is available.

## Solution
- Keeper image: `latest` (only option)
- Main ClickHouse: `24.8.5-debian-12` (still available)
- Using `pullPolicy: IfNotPresent` to minimize update churn

## Verification
Confirm both `clickhouse-shard0-0` and `clickhouse-keeper-0` reach Running.