### PR TITLE
fix: disable Keeper (image removed from Docker Hub)

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -66,12 +66,9 @@ resource "helm_release" "clickhouse" {
         enabled = false # Disable external ZooKeeper
       }
       keeper = {
-        enabled = true # Enable bundled ClickHouse Keeper
-        image = {
-          # Bitnami removed versioned tags after Aug 2025, only 'latest' available
-          tag        = "latest"
-          pullPolicy = "IfNotPresent"
-        }
+        # bitnami/clickhouse-keeper image has been REMOVED from Docker Hub entirely
+        # Single-node ClickHouse works without Keeper for MVP
+        enabled = false
       }
       persistence = {
         enabled      = true


### PR DESCRIPTION
## Root Cause
`bitnami/clickhouse-keeper` image has been **completely removed** from Docker Hub.
- `24.8.5-debian-12`: not found
- `latest`: not found

## Solution
Disable Keeper. Single-node ClickHouse works without it for MVP.

## Future
If Keeper is needed, consider using official `clickhouse/clickhouse-keeper` image instead of Bitnami.