### PR TITLE
fix: use official ClickHouse Keeper image instead of Bitnami

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -66,9 +66,14 @@ resource "helm_release" "clickhouse" {
         enabled = false # Disable external ZooKeeper
       }
       keeper = {
-        # bitnami/clickhouse-keeper image has been REMOVED from Docker Hub entirely
-        # Single-node ClickHouse works without Keeper for MVP
-        enabled = false
+        enabled = true
+        image = {
+          # Use official ClickHouse Keeper image (Bitnami's was removed from Docker Hub)
+          registry   = "docker.io"
+          repository = "clickhouse/clickhouse-keeper"
+          tag        = "24.8"  # Matches main ClickHouse version
+          pullPolicy = "IfNotPresent"
+        }
       }
       persistence = {
         enabled      = true


### PR DESCRIPTION
## Root Cause
`bitnami/clickhouse-keeper` image has been **completely removed from Docker Hub**.
Both versioned tags and `latest` return 404.

## Research
Found that official `clickhouse/clickhouse-keeper` image exists and is actively maintained:
- `clickhouse/clickhouse-keeper:latest` ✅
- `clickhouse/clickhouse-keeper:24.8` ✅
- `clickhouse/clickhouse-keeper:25.7` ✅

## Solution
Configure Bitnami Helm Chart to use official ClickHouse Keeper image:
```yaml
keeper:
  image:
    registry: docker.io
    repository: clickhouse/clickhouse-keeper
    tag: "24.8"
```

## Reference
- https://hub.docker.com/r/clickhouse/clickhouse-keeper

## Verification
Confirm `clickhouse-keeper-0` pod starts with official image.