### PR TITLE
fix: use bitnamilegacy/clickhouse-keeper (Bitnami moved images)

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -68,10 +68,10 @@ resource "helm_release" "clickhouse" {
       keeper = {
         enabled = true
         image = {
-          # Use official ClickHouse Keeper image (Bitnami's was removed from Docker Hub)
+          # Bitnami moved clickhouse-keeper to bitnamilegacy repo (bitnami/ is empty)
           registry   = "docker.io"
-          repository = "clickhouse/clickhouse-keeper"
-          tag        = "24.8"  # Matches main ClickHouse version
+          repository = "bitnamilegacy/clickhouse-keeper"
+          tag        = "25.7.5-debian-12-r0"  # Matches Chart 9.4.4 default
           pullPolicy = "IfNotPresent"
         }
       }


### PR DESCRIPTION
## Root Cause
Bitnami moved `clickhouse-keeper` from `bitnami/` to `bitnamilegacy/` repository.

**Verification via Docker Hub Registry V2 API:**
- `bitnami/clickhouse-keeper`: 0 tags (empty)
- `bitnamilegacy/clickhouse-keeper`: 100+ tags ✅

## Solution
Use `bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0` which is the exact tag that Helm Chart 9.4.4 defaults to.

## Technical Details
- Same Bitnami image format - compatible with Bitnami Helm Chart templates
- Same tag `25.7.5-debian-12-r0` that Chart expects
- Just different repository prefix (`bitnamilegacy/` instead of `bitnami/`)

## Verification
Confirm both `clickhouse-shard0-0` and `clickhouse-keeper-*` pods reach Running state.