### PR TITLE
fix: use bitnamilegacy for BOTH clickhouse and clickhouse-keeper

### DIFF
--- a/3.data/3.clickhouse.tf
+++ b/3.data/3.clickhouse.tf
@@ -51,9 +51,11 @@ resource "helm_release" "clickhouse" {
 
   values = [
     yamlencode({
-      # Pin both main and keeper images to avoid ImagePullBackOff
+      # Bitnami moved all images to bitnamilegacy repo (bitnami/ is empty)
       image = {
-        tag        = "24.8.5-debian-12" # Pin to valid rolling tag
+        registry   = "docker.io"
+        repository = "bitnamilegacy/clickhouse"
+        tag        = "25.7.5-debian-12-r0"  # Matches Chart 9.4.4 default
         pullPolicy = "IfNotPresent"
       }
       auth = {


### PR DESCRIPTION
## Root Cause
BOTH `bitnami/clickhouse` AND `bitnami/clickhouse-keeper` repos are empty.
Bitnami migrated ALL images to `bitnamilegacy/` repository.

## Previous PR #202 Issue
Only fixed Keeper image, forgot to fix main ClickHouse image.

## This Fix
**Now using:**
- `bitnamilegacy/clickhouse:25.7.5-debian-12-r0`
- `bitnamilegacy/clickhouse-keeper:25.7.5-debian-12-r0`

**Verified via Docker Hub Registry V2 API:**
- `bitnamilegacy/clickhouse`: 1146 tags ✅
- `bitnamilegacy/clickhouse-keeper`: 100+ tags ✅

## Verification
Confirm all ClickHouse pods reach Running state:
- `clickhouse-shard0-0`
- `clickhouse-keeper-*`