### PR TITLE
docs(platform): trigger Portal SSO Gate deployment

### DIFF
--- a/2.platform/README.md
+++ b/2.platform/README.md
@@ -96,4 +96,19 @@ Note: `base_domain` (`truealpha.club`) is for business/production apps, `interna
 - **Lost Admin Access**: Recover using stored root token/unseal keys.
 
 ---
-*Last updated: 2025-12-13*
+
+### Portal SSO Gate Deployment
+
+**Status**: Ready to deploy (enable_portal_sso_gate=true in Atlantis config)
+
+To deploy Portal SSO Gate for Vault/Dashboard/Kubero:
+1. This PR triggers Atlantis to run `terraform plan -d 2.platform`
+2. Review the plan (should show portal-auth resources and Ingress middleware annotations)
+3. Comment `atlantis apply -d 2.platform` to deploy
+4. Verify SSO login at:
+   - https://secrets.zitian.party (Vault)
+   - https://kdashboard.zitian.party (Dashboard)
+   - https://kcloud.zitian.party (Kubero)
+
+---
+*Last updated: 2025-12-15*


### PR DESCRIPTION
## Summary

Trigger Atlantis to deploy Portal SSO Gate infrastructure for Vault/Dashboard/Kubero.

## Background

- Portal SSO Gate feature was merged in #172
- Atlantis config already sets `enable_portal_sso_gate=true`
- But `terraform apply` hasn't run yet to deploy the actual resources
- Users report no SSO displayed on Vault/Dashboard/Kubero

## Changes

- Add deployment instructions to `2.platform/README.md`
- Trigger Atlantis plan/apply workflow

## Deployment Plan

When `atlantis plan -d 2.platform` runs, it should show:

**New resources**:
- `helm_release.portal_auth` - OAuth2-Proxy for SSO gate
- `kubernetes_manifest.portal_auth_middleware_platform` - Traefik middleware
- `kubernetes_manifest.portal_auth_middleware_kubero` - Traefik middleware
- Updated Casdoor `init_data` with 4 OIDC apps (portal-gate, vault-oidc, dashboard-oidc, kubero-oidc)

**Modified resources**:
- `kubernetes_ingress_v1.vault` - Add middleware annotation
- `kubernetes_ingress_v1.dashboard` - Add middleware annotation
- `kubectl_manifest.kubero_instance` - Add middleware annotation

## Testing Steps

After `atlantis apply -d 2.platform`:

1. Visit https://secrets.zitian.party → Should redirect to Casdoor login
2. Visit https://kdashboard.zitian.party → Should redirect to Casdoor login
3. Visit https://kcloud.zitian.party → Should redirect to Casdoor login
4. Login with GitHub OAuth → Should access the services

## Rollback Plan

If SSO breaks access, disable the gate:
1. Set `TF_VAR_enable_portal_sso_gate=false` in Atlantis config
2. Re-run `atlantis apply -d 2.platform`
3. Services will revert to original auth (Token-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)