### PR TITLE
fix(ci): disable terraform wrapper globally to fix script failures

### DIFF
--- a/.github/actions/terraform-setup/action.yml
+++ b/.github/actions/terraform-setup/action.yml
@@ -112,6 +112,7 @@ runs:
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform_version }}
+        terraform_wrapper: false
 
     - name: Validate secrets
       shell: bash


### PR DESCRIPTION
## Emergency Fix for CI

### Problem
CI run 20234068287 failed with `Terraform exited with code 1` during the 'Import Existing Resources' step, even though the script logic handles the exit code.

### Root Cause
The `hashicorp/setup-terraform` action defaults to `terraform_wrapper: true`. This wrapper intercepts the exit code (1) of `terraform state show` and fails the step, bypassing shell script error handling.

### Fix
- Set `terraform_wrapper: false` in `.github/actions/terraform-setup/action.yml`.
- This allows the shell script to correctly catch exit code 1 (resource not found) and proceed with cleanup.

Please merge immediately.