### PR TITLE
ci: disable terraform wrapper

### DIFF
--- a/.github/actions/terraform-setup/README.md
+++ b/.github/actions/terraform-setup/README.md
@@ -8,6 +8,7 @@ A composite GitHub Action that sets up the Terraform environment for CI/CD workf
 2. **tfvars Rendering**: Generates `terraform.tfvars` from GitHub Secrets.
 3. **Terraform Init**: Initializes Terraform with R2 backend configuration.
 4. **Kubeconfig Fetch**: Retrieves kubeconfig from VPS for Helm provider.
+5. **Terraform Wrapper**: Runs `hashicorp/setup-terraform@v3` with `terraform_wrapper: false` so wrapper instrumentation does not intercept `terraform` exit codes and scripts can safely catch failed `state show`/`state rm` checks.
 
 ## Inputs
 

--- a/.github/actions/terraform-setup/action.yml
+++ b/.github/actions/terraform-setup/action.yml
@@ -112,6 +112,7 @@ runs:
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform_version }}
+        terraform_wrapper: false
 
     - name: Validate secrets
       shell: bash

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,6 +41,8 @@ PR 创建/更新
 3. `terraform validate` - 语法验证 (L1/L2/L3/L4, `init -backend=false`)
 4. **发布 infra-flash 评论**：每个 commit push 新建一条评论，记录 CI 结果和下一步指引
 
+> CI 里调用 `hashicorp/setup-terraform@v3` 时将 `terraform_wrapper: false`，避免 wrapper 在我们用 `if ! terraform state show`/`state rm` 等命令处理缺失资源时把失败直接上抛，确保脚本可以按逻辑处理 exit code。
+
 ### infra-flash 评论（Per-Commit）
 
 - PR 中**每个 commit**都会生成独立评论：`<!-- infra-flash-commit:abc1234 -->`

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -38,6 +38,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.6.6
+          terraform_wrapper: false
 
       # ============================================================
       # Static Analysis (all layers)


### PR DESCRIPTION
## Summary
- disable hashicorp/setup-terraform's wrapper in  and the shared terraform-setup action so our shell logic can handle Usage: terraform [global options] state <subcommand> [options] [args]

  This command has subcommands for advanced state management.

  These subcommands can be used to slice and dice the Terraform state.
  This is sometimes necessary in advanced cases. For your safety, all
  state management commands that modify the state create a timestamped
  backup of the state prior to making modifications.

  The structure and output of the commands is specifically tailored to work
  well with the common Unix utilities such as grep, awk, etc. We recommend
  using those tools to perform more advanced state tasks.

Subcommands:
    identities          List the identities of resources in the state
    list                List resources in the state
    mv                  Move an item in the state
    pull                Pull current state and output to stdout
    push                Update remote state from a local state file
    replace-provider    Replace provider in the state
    rm                  Remove instances from the state
    show                Show a resource in the state returning 1 without the action failing immediately
- document the new runner behavior in the workflow and action READMEs

## Testing
- Not run (workflow changes only)