### PR TITLE
fix(ci): make deploy-k3s idempotent for Atlantis release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -104,6 +104,9 @@ Atlantis 评论 "Ran Plan for..."
 
 用于部署/更新 L1 Bootstrap（k3s + Atlantis 等）。L2+ 日常变更通过 Atlantis 处理。
 
+一致性策略：
+- CI 不做破坏性 “自愈”（不 `terraform state rm`、不删集群内资源）；仅在需要时 `terraform import` 以把已存在的资源纳入 state 管理（例如 `helm_release.atlantis`）。
+
 ---
 
 ## dig.yml {#health-check}

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -71,6 +71,11 @@ jobs:
           chmod +x 0.tools/preflight-check.sh
           0.tools/preflight-check.sh
 
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.28.4
+
       # Import existing k8s resources that Terraform wants to manage
       # This prevents "already exists" errors when adopting existing resources
       - name: Import Existing Resources
@@ -85,22 +90,14 @@ jobs:
             terraform import kubernetes_config_map_v1.local_path_config kube-system/local-path-config || true
           fi
           
-          # Fix orphaned Atlantis state: remove from state to allow fresh install
-          # The helm command might not be available here, so we skip the check
-          # Fix orphaned Atlantis state: remove from state to allow fresh install
-          # The helm command might not be available here, so we skip the check
+          # If Atlantis already exists in cluster but was lost from state, import it.
+          # Never remove state or delete in-cluster resources automatically from CI.
           if terraform state show helm_release.atlantis 2>/dev/null; then
-              echo "Cleaning up Atlantis state to fix Helm conflict..."
-              terraform state rm helm_release.atlantis || true
+            echo "Atlantis helm_release already tracked in Terraform state."
+          else
+            echo "Attempting to import existing Atlantis helm release (if present)..."
+            terraform import helm_release.atlantis bootstrap/atlantis || true
           fi
-          
-          # Force clean Helm secrets to prevent "cannot re-use a name" error
-          # This handles the case where Terraform state is clean but Cluster has lingering Helm release
-          echo "Force cleaning lingering Helm secrets..."
-          kubectl delete secret -n platform -l name=atlantis -l owner=helm || true
-          kubectl delete deployment -n platform atlantis || true
-          kubectl delete svc -n platform atlantis || true
-          kubectl delete statefulset -n platform atlantis || true
 
       # Apply all infrastructure (moved blocks require full apply, not targeted)
       # Note: -target=module.nodep fails when moved.tf has pending resource moves
@@ -115,10 +112,6 @@ jobs:
             kubectl describe pods -n platform 2>/dev/null | tail -50 || true
             exit 1
           }
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: v1.28.4
 
       - name: Smoke test
         env:


### PR DESCRIPTION
## Root cause
`deploy-k3s.yml` 之前做了破坏性“自愈”：会把 `helm_release.atlantis` 从 Terraform state 里删掉（甚至尝试删集群内资源），导致下一步 `terraform apply` 认为需要重新 *create* Helm release，而集群里同名 release 仍存在，于是报错：`cannot re-use a name that is still in use`。

## Fix
- 把 `kubectl` 安装提前到 `terraform apply` 之前，保证失败时的诊断命令可用
- CI 不再做破坏性操作（不 `terraform state rm`、不删除集群资源）
- 若 Atlantis 已存在但 state 丢失，则通过 `terraform import helm_release.atlantis bootstrap/atlantis` 纳入 state 管理
- 同步更新 `.github/workflows/README.md` 的一致性说明

## Testing
- 未在本地运行（仅 GitHub Actions workflow 变更）
