### PR TITLE
ci: make Claude Code best-effort

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -135,6 +135,7 @@ AI 代码审查：
 - 检查 Terraform 结构
 - 验证 SSOT 一致性
 - 识别潜在问题
+- 可靠性：该 workflow 为 best-effort（`continue-on-error: true`），失败不会阻塞主流水线
 
 ---
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Run Claude
         id: claude
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -66,7 +67,7 @@ jobs:
             actions: read
           prompt: |
             REPO: ${{ github.repository }}
-            PR/ISSUE: ${{ github.event.issue.number }}
+            PR/ISSUE: ${{ github.event.issue.number || github.event.pull_request.number }}
 
             This is a Terraform IaC project with layered architecture (L1-L4).
 


### PR DESCRIPTION
## 背景
`Claude Code` workflow 在主干上经常出现不稳定失败（action 返回 `is_error: true`，但默认隐藏详细输出），导致 Actions 列表里持续出现红色失败，形成 CI 噪音。

## 变更
- 将 `Run Claude` step 设置为 best-effort：`continue-on-error: true`，Claude 失败不再阻塞主流水线
- `PR/ISSUE` 参数增加 fallback：兼容 `pull_request_review*` 事件（`issue.number` 不存在时使用 `pull_request.number`）
- 同步更新 `.github/workflows/README.md`

## 验证
- 未在本地执行（仅 workflow 语义调整）
