### PR TITLE
fix(bootstrap): disable cf proxy for secrets to fix sso loop

### DIFF
--- a/1.bootstrap/3.dns_and_cert.tf
+++ b/1.bootstrap/3.dns_and_cert.tf
@@ -3,7 +3,7 @@
 locals {
   infra_dns_records = {
     atlantis   = true  # HTTPS via proxy
-    secrets    = true  # HTTPS via proxy
+    secrets    = false # Vault - DNS only (avoid Cloudflare caching issues with OIDC)
     kdashboard = true  # HTTPS via proxy
     kcloud     = true  # HTTPS via proxy
     kapi       = true  # HTTPS via proxy


### PR DESCRIPTION
Change secrets.zitian.party to DNS-only to match sso.zitian.party configuration and avoid OIDC/Proxy issues.