### PR TITLE
docs: align pipeline SSOT with workflows

### DIFF
--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -13,7 +13,7 @@
 | [k3s.md](./k3s.md) | 集群与 PaaS | K3s、StorageClass、Kubero、Namespace 规范 |
 | [vars.md](./vars.md) | 非密钥变量 | TF_VAR 列表、默认值、Feature Flags |
 | [secrets.md](./secrets.md) | 密钥管理 | 四层模型、1Password 清单、Vault（SSOT） |
-| [pipeline.md](./pipeline.md) | 流程汇总 | CI 语法检查 + Atlantis autoplan plan/apply、infra-flash per-commit 评论、灾备 |
+| [pipeline.md](./pipeline.md) | 流程汇总 | PR CI（fmt/tflint/validate + infra-flash per-commit）+ Atlantis autoplan plan/apply + deploy-k3s（bootstrap/recovery apply） |
 | [db.md](./db.md) | 数据库分布 | Platform PG (L1) vs Business DBs (L3) |
 | [auth.md](./auth.md) | 统一认证 | Casdoor SSO 门户覆盖与 1Password/Vault 密钥策略 |
 | [network.md](./network.md) | 域名规则 | Internal vs Env 模式 |


### PR DESCRIPTION
对齐 `docs/ssot/pipeline.md` 与实际 GitHub Actions workflows：

- 修正 infra-flash 为 per-commit；PR CI 仅做 fmt/tflint/validate（init -backend=false）
- 补充/纠正 `deploy-k3s.yml` 当前行为：bootstrap/recovery 按顺序 apply L1→L2→L3→L4（部分 step 仅在 push 执行）
- 理想态统一用 TODO 框标注（破坏性清理显式开关、L2+ 日常变更仅走 Atlantis 等）

涉及：
- `.github/workflows/README.md`
- `docs/ssot/pipeline.md`
- `docs/ssot/README.md`
