### PR TITLE
fix(ci): complete audit - add required terraform-setup inputs to L2/L3/L4

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -148,8 +148,9 @@ jobs:
           vps_ssh_key: ${{ secrets.VPS_SSH_KEY }}
           vps_user: ${{ secrets.VPS_USER }}
           vps_ssh_port: ${{ secrets.VPS_SSH_PORT }}
-          vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
           github_token: ${{ secrets.GH_PAT || github.token }}
+          atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           base_domain: ${{ secrets.BASE_DOMAIN }}
@@ -157,6 +158,7 @@ jobs:
           internal_zone_id: ${{ secrets.INTERNAL_ZONE_ID }}
           github_oauth_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           github_oauth_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
 
       - name: Apply Infrastructure (L2 - Platform)
         working-directory: 2.platform
@@ -196,6 +198,12 @@ jobs:
           vps_ssh_key: ${{ secrets.VPS_SSH_KEY }}
           vps_user: ${{ secrets.VPS_USER }}
           vps_ssh_port: ${{ secrets.VPS_SSH_PORT }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
+          github_token: ${{ secrets.GH_PAT || github.token }}
+          atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
+          cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          base_domain: ${{ secrets.BASE_DOMAIN }}
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
 
       - name: Pre-flight Image Check (L3)
@@ -279,8 +287,13 @@ jobs:
           vps_ssh_key: ${{ secrets.VPS_SSH_KEY }}
           vps_user: ${{ secrets.VPS_USER }}
           vps_ssh_port: ${{ secrets.VPS_SSH_PORT }}
-          vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
+          vault_postgres_password: ${{ secrets.VAULT_POSTGRES_PASSWORD }}
+          github_token: ${{ secrets.GH_PAT || github.token }}
+          atlantis_webhook_secret: ${{ secrets.ATLANTIS_WEBHOOK_SECRET }}
+          cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           base_domain: ${{ secrets.BASE_DOMAIN }}
+          vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
 
       - name: Apply Infrastructure (L4 - Apps)
         if: github.event_name == 'push'


### PR DESCRIPTION
Adds all missing required inputs to L2/L3/L4 terraform-setup calls:
- vault_postgres_password
- atlantis_webhook_secret
- github_token
- cloudflare_api_token
- cloudflare_zone_id
- base_domain

This resolves 'Missing atlantis_webhook_secret' and similar failures.