### PR TITLE
fix(ci): complete audit + vault_address for external access

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -159,6 +159,7 @@ jobs:
           github_oauth_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           github_oauth_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
+          vault_address: https://secrets.${{ secrets.BASE_DOMAIN }}
 
       - name: Apply Infrastructure (L2 - Platform)
         working-directory: 2.platform
@@ -205,6 +206,7 @@ jobs:
           cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           base_domain: ${{ secrets.BASE_DOMAIN }}
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
+          vault_address: https://secrets.${{ secrets.BASE_DOMAIN }}
 
       - name: Pre-flight Image Check (L3)
         if: github.event_name == 'push'
@@ -294,6 +296,7 @@ jobs:
           cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           base_domain: ${{ secrets.BASE_DOMAIN }}
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
+          vault_address: https://secrets.${{ secrets.BASE_DOMAIN }}
 
       - name: Apply Infrastructure (L4 - Apps)
         if: github.event_name == 'push'


### PR DESCRIPTION
## Changes

### 1. Complete terraform-setup input audit
Added all missing required inputs to L2/L3/L4 terraform-setup calls:
- vault_postgres_password
- atlantis_webhook_secret
- github_token
- cloudflare_api_token
- cloudflare_zone_id
- base_domain

### 2. Vault Address Fix
Added `vault_address: https://secrets.$BASE_DOMAIN` to L2/L3/L4.

**Root Cause**: CI runner is external to K8s cluster, so cannot resolve internal DNS (`vault.platform.svc.cluster.local`). Using external URL fixes this.

### 3. L3 Health Check Auth
Added password retrieval from K8s secrets for Redis and ClickHouse connectivity checks.