### PR TITLE
docs: wikipedia-style SSOT navigation + backlinks

### DIFF
--- a/1.bootstrap/README.md
+++ b/1.bootstrap/README.md
@@ -38,6 +38,11 @@ Managed by **GitHub Actions only** (not Atlantis).
 - DNS inputs: `CLOUDFLARE_ZONE_ID` for `BASE_DOMAIN`; `INTERNAL_ZONE_ID` optionally overrides infra zone (falls back to `CLOUDFLARE_ZONE_ID`). Infra records are explicit A records with per-host proxy (443 services proxied, `k3s` DNS-only).
 - Certificates: wildcard for `BASE_DOMAIN`; wildcard for `INTERNAL_DOMAIN` when distinct (separate secret). Ingresses also request per-host certs via cert-manager ingress shim.
 
+SSOT:
+- [docs/ssot/env.md](../docs/ssot/env.md) (environment semantics)
+- [docs/ssot/network.md](../docs/ssot/network.md) (domain rules and service mapping)
+- [docs/ssot/storage.md](../docs/ssot/storage.md) (StorageClass and data retention)
+
 ## Bootstrap Command
 
 ```bash
@@ -73,4 +78,4 @@ L1 Atlantis passes the following variables to L2/L3:
 - **Image Pin**: Use the chart default image tag (pinned via chart version). Do **NOT** override to `latest` (breaks reproducibility).
 
 ---
-*Last updated: 2025-12-13*
+*Last updated: 2025-12-16*

--- a/1.bootstrap/network.md
+++ b/1.bootstrap/network.md
@@ -1,6 +1,6 @@
 # Network & Domain Architecture
 
-> Aligned with [AGENTS.md](../../AGENTS.md) 4-Layer Design (L1-L4).
+> Aligned with [AGENTS.md](../AGENTS.md) 4-Layer Design (L1-L4).
 
 ## 1. DNS Architecture
 

--- a/2.platform/README.md
+++ b/2.platform/README.md
@@ -83,7 +83,7 @@ Note: `base_domain` (`truealpha.club`) is for business/production apps, `interna
 ### Known Issues
 
 - **Vault init/unseal**: Manual init/unseal required after deploy; store keys outside Terraform.
-- **PostgreSQL storage**: Uses `local-path-retain` StorageClass (reclaimPolicy=Retain) to keep PV data after PVC deletion.
+- **PostgreSQL storage**: Uses `local-path-retain` StorageClass (reclaimPolicy=Retain) to keep PV data after PVC deletion. See [docs/ssot/storage.md](../docs/ssot/storage.md).
 - **PostgreSQL upgrades**: `helm_release.postgresql` uses `force_update=true` to allow spec changes (e.g., auth tweaks). Expect pod recreation/downtime during upgrades.
 - **Namespace ownership**: `platform` namespace is created in L1 (`1.bootstrap/5.platform_pg.tf`), not L2. The Atlantis workflow removes stale namespace refs from L2 state automatically.
 - **Casdoor login bug**: Requires `copyrequestbody = true` in `app.conf` to fix "unexpected end of JSON input" error. See [#3224](https://github.com/casdoor/casdoor/issues/3224).
@@ -110,4 +110,4 @@ To deploy Portal SSO Gate for Vault/Dashboard/Kubero:
    - https://kcloud.zitian.party (Kubero)
 
 ---
-*Last updated: 2025-12-15*
+*Last updated: 2025-12-16*

--- a/4.apps/README.md
+++ b/4.apps/README.md
@@ -24,6 +24,12 @@ This layer deploys business applications. All non-production environments go to 
 | Backend API | Business logic |
 | Workers | Background jobs |
 
+## SSOT Links
+
+- [docs/ssot/env.md](../docs/ssot/env.md) - Environment ↔ workspace/namespace/domain model
+- [docs/ssot/network.md](../docs/ssot/network.md) - Domain rules and routing
+- [docs/ssot/pipeline.md](../docs/ssot/pipeline.md) - PR → Plan/Apply workflow (Atlantis + infra-flash)
+
 ### Usage
 
 ```bash
@@ -37,4 +43,4 @@ atlantis apply -p apps-prod
 ```
 
 ---
-*Last updated: 2025-12-09*
+*Last updated: 2025-12-16*

--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
-# GitHub Automation
-- **swap**: the README.md and .github/README.md change the position.
-- the .github/README.md is the project level single source of truth
+# codex_infra
 
-CI/CD and bot configuration live here. Workflows under `workflows/` drive Terraform checks and other automation.
+单 VPS、自托管的基础设施仓库（Terraform + k3s + Atlantis），按 L0–L4 分层组织。
 
-## Workflows Overview
+## Start Here
+
+- AI 入口：[`AGENTS.md`](./AGENTS.md)
+- 当前上下文：[`0.check_now.md`](./0.check_now.md)
+- 目录结构 SSOT（入口）：[`docs/dir.md`](./docs/dir.md)（权威内容在 `docs/ssot/dir.md`）
+- 话题 SSOT 索引：[`docs/ssot/README.md`](./docs/ssot/README.md)
+- Layer 文档：[`0.tools/README.md`](./0.tools/README.md) · [`1.bootstrap/README.md`](./1.bootstrap/README.md) · [`2.platform/README.md`](./2.platform/README.md) · [`3.data/README.md`](./3.data/README.md) · [`4.apps/README.md`](./4.apps/README.md)
+- GitHub 自动化入口：[`.github/README.md`](./.github/README.md) · [`.github/workflows/README.md`](./.github/workflows/README.md)
+
+## GitHub Automation（CI/CD）
+
+CI/CD 与 bot 配置位于 `.github/`；Workflows 在 `.github/workflows/`。
 
 | Workflow | Purpose |
 | :--- | :--- |
-| `terraform-plan.yml` | Validates Terraform and posts per-commit infra-flash status; Atlantis autoplan runs plan on PR updates |
-| `deploy-k3s.yml` | Deploys infrastructure on push to main |
-| `docs-guard.yml` | Enforces `0.check_now.md` and README updates |
+| `terraform-plan.yml` | Static checks + per-commit infra-flash comment; Atlantis autoplan runs plan on PR updates |
+| `infra-flash-update.yml` | Appends Atlantis plan/apply results to the matching infra-flash comment |
+| `deploy-k3s.yml` | Deploys bootstrap (L1) on push to main |
 | `claude.yml` | AI code review via Claude GitHub App (auto after Atlantis success comment, or manual `/review`/`@claude`/`PTAL`) |
 
-Documentation guard enforces updating `0.check_now.md` and directory `README.md` files whenever code changes land.
+Per-commit infra-flash 评论流（CI → (autoplan) Plan/Apply 追加）见 [`docs/ssot/pipeline.md`](./docs/ssot/pipeline.md)。
 
-Per-commit infra-flash 评论流（CI → (autoplan) Plan/Apply 追加）见 `docs/ssot/pipeline.md`。
-
-For detailed CI/CD design philosophy, plan/apply/revert workflows, see [workflows/README.md](./workflows/README.md).
+更完整的 CI/CD 设计与变更流程见 [`.github/workflows/README.md`](./.github/workflows/README.md)。
 
 ---
-*Last updated: 2025-12-15*
+*Last updated: 2025-12-16*

--- a/docs/BRN-004.env_eaas_design.md
+++ b/docs/BRN-004.env_eaas_design.md
@@ -1,0 +1,6 @@
+# BRN-004.env_eaas_design.md（兼容入口）
+
+> 兼容入口：历史文档可能引用 `docs/BRN-004.env_eaas_design.md`。  
+> 权威版本已迁移到：[`docs/project/BRN-004.md`](./project/BRN-004.md)。
+
+- ✅ **SSOT**：[`docs/project/BRN-004.md`](./project/BRN-004.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,11 @@
 ## Key Documents
 
 - **[SSOT 话题文档](./ssot/README.md)** - 密钥/流程/数据库/认证/网络
-- [Directory Structure](./ssot/dir.md) - Navigation entry (links to apps/ and infra docs)
+- [Directory Map (入口)](./dir.md) - 目录结构入口（权威内容在 `./ssot/dir.md`）
 - [Project Implementation Status](./project/README.md) - Active BRNs and execution state
 - [Current Context](../0.check_now.md) and [Change Log](./change_log) - Sprint notes and history roll-ups
-- [Env & EaaS Design (BRN-004)](./BRN-004.env_eaas_design.md)
+- [Env & EaaS Design (BRN-004)](./project/BRN-004.md)
 - Design Decisions: [DD-001](./deep_dives/DD-001.secret_and_ci_practices.md) (Secrets & CI) · [DD-002](./deep_dives/DD-002.why_atlantis.md) (Atlantis rationale)
 
 ---
-*Last updated: 2025-12-12*
-
+*Last updated: 2025-12-16*

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -1,0 +1,18 @@
+# Directory Map（入口）
+
+> 兼容入口：历史文档与 `AGENTS.md` 可能引用 `docs/dir.md`。  
+> **目录结构 SSOT** 已迁移到：[`docs/ssot/dir.md`](./ssot/dir.md)。
+
+- ✅ **SSOT（目录结构）**：[`docs/ssot/dir.md`](./ssot/dir.md)
+- 🧭 **SSOT 索引**：[`docs/ssot/README.md`](./ssot/README.md)
+- 📚 **Docs Center**：[`docs/README.md`](./README.md)
+
+## 为什么保留本文件？
+
+- 稳定链接（类似 Wikipedia 的 redirect 页面），避免外部/历史引用 404。
+- 防止重复维护两份目录树：**SSOT 仅在 `docs/ssot/dir.md`**。
+
+## 另见
+
+- [`AGENTS.md`](../AGENTS.md)
+- [`0.check_now.md`](../0.check_now.md)

--- a/docs/project/BRN-004.md
+++ b/docs/project/BRN-004.md
@@ -3,9 +3,9 @@
 > **这是最终的全景架构设计**，整合了 BRN-004（Staging MVP）、BRN-007（五环境）以及所有基础设施、平台、观测等选型。
 
 **关联文档 (Apps Submodule)**：
-- [应用架构 (Apps Arch)](../apps/docs/arch.md)
-- [应用文档索引 (Apps Index)](../apps/docs/index.md)
-- [项目规格 (Specs)](../apps/docs/specs)
+- [应用架构 (Apps Arch)](../../apps/docs/arch.md)
+- [应用文档索引 (Apps Index)](../../apps/docs/index.md)
+- [项目规格 (Specs)](../../apps/docs/specs)
 
 ---
 

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -16,3 +16,10 @@
 ## Archived Projects
 
 (None)
+
+## Related
+
+- [apps/docs/index.md](../../apps/docs/index.md) - Apps documentation index (submodule)
+
+---
+*Last updated: 2025-12-16*

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -22,6 +22,12 @@
 | [storage.md](./storage.md) | 存储与文件系统 | /data、StorageClass、R2 备份与同步 |
 | [ai.md](./ai.md) | AI 接入 | OpenRouter、变量/密钥、注入方式 |
 
+## 维护约定（SSOT → Wikipedia 风格）
+
+- **固定格式**：每个 SSOT 页面最后包含 `Used by（反向链接）`，用于双向链接（类似 “What links here”）。
+- **避免漂移**：一处信息 SSOT 化后，其他文档只保留摘要并链接到该 SSOT 页面。
+- **稳定链接**：如需调整路径，优先保留旧路径的入口页（redirect），避免外部引用 404（例如 `docs/dir.md`）。
+
 ## 层级架构
 
 ```

--- a/docs/ssot/ai.md
+++ b/docs/ssot/ai.md
@@ -44,3 +44,10 @@ App Pod（/vault/secrets/*）
 |------|------|
 | OpenRouter Key 管理 | ⏳ 未配置 |
 | 应用侧 SDK 接入 | ⏳ 未落地 |
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [docs/ssot/secrets.md](./secrets.md)

--- a/docs/ssot/alerting.md
+++ b/docs/ssot/alerting.md
@@ -44,3 +44,10 @@
 
 - 可观测性选型：`docs/ssot/observability.md`
 - 域名规则：`docs/ssot/network.md`
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [docs/ssot/observability.md](./observability.md)

--- a/docs/ssot/auth.md
+++ b/docs/ssot/auth.md
@@ -152,3 +152,11 @@ L2 门户级服务正在按照 BRN-008 的设计，逐步迁移到 Casdoor 提�
 - [secrets.md](secrets.md) - 密钥管理 SSOT
 - [5.casdoor.tf](../../2.platform/5.casdoor.tf) - Casdoor 部署
 - [2.secret.tf](../../2.platform/2.secret.tf) - Vault 配置
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [2.platform/README.md](../../2.platform/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)

--- a/docs/ssot/db.md
+++ b/docs/ssot/db.md
@@ -212,4 +212,13 @@ EOF
 
 - Platform PG: [1.bootstrap/5.platform_pg.tf](../../1.bootstrap/5.platform_pg.tf)
 - L3 Data: [3.data/](../../3.data/)
-- Vault Config: [2.platform/2.vault.tf](../../2.platform/2.vault.tf)
+- Vault Config: [2.platform/2.secret.tf](../../2.platform/2.secret.tf)
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [3.data/README.md](../../3.data/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/ssot/storage.md](./storage.md)

--- a/docs/ssot/dir.md
+++ b/docs/ssot/dir.md
@@ -64,7 +64,7 @@ root/
 │   ├── locals.tf                # 本地变量
 │   ├── 1.k3s.tf                 # K3s 安装
 │   ├── 2.atlantis.tf            # Atlantis
-│   ├── 3.dns_cert.tf            # DNS + Cert-Manager
+│   ├── 3.dns_and_cert.tf        # DNS + Cert-Manager
 │   ├── 4.storage.tf             # 存储类
 │   └── 5.platform_pg.tf         # Platform PostgreSQL
 │
@@ -166,3 +166,15 @@ root/
 |------|------|
 | `docs/ssot/env.md` | 环境模型 |
 | `docs/ssot/pipeline.md` | 部署流程 |
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [README.md](../../README.md)
+- [docs/README.md](../README.md)
+- [docs/dir.md](../dir.md)
+- [3.data/README.md](../../3.data/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/ssot/storage.md](./storage.md)

--- a/docs/ssot/env.md
+++ b/docs/ssot/env.md
@@ -137,3 +137,12 @@
 3. **以为 L2 也是多环境**  
    - 当前 SSOT 明确：L2 是单例（platform workspace）。
 
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [1.bootstrap/README.md](../../1.bootstrap/README.md)
+- [4.apps/README.md](../../4.apps/README.md)
+- [envs/README.md](../../envs/README.md)
+- [docs/ssot/dir.md](./dir.md)

--- a/docs/ssot/k3s.md
+++ b/docs/ssot/k3s.md
@@ -74,3 +74,11 @@ Kubero 是 L2 平台的 PaaS 组件，用于部署应用：
 - K3s: [`1.bootstrap/1.k3s.tf`](../../1.bootstrap/1.k3s.tf)
 - 存储: [`1.bootstrap/4.storage.tf`](../../1.bootstrap/4.storage.tf)
 - Kubero: [`2.platform/4.kubero.tf`](../../2.platform/4.kubero.tf)
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [docs/ssot/storage.md](./storage.md)
+- [docs/change_log/2025-12-12.brn_008_infrastructure_ssot.md](../change_log/2025-12-12.brn_008_infrastructure_ssot.md)

--- a/docs/ssot/network.md
+++ b/docs/ssot/network.md
@@ -55,3 +55,15 @@ nginx.ingress.kubernetes.io/whitelist-source-range: "140.82.112.0/20,185.199.108
 - DNS 配置: [`1.bootstrap/3.dns_and_cert.tf`](../../1.bootstrap/3.dns_and_cert.tf)
 - Atlantis Ingress: [`1.bootstrap/2.atlantis.tf`](../../1.bootstrap/2.atlantis.tf)
 - Network 详情: [`1.bootstrap/network.md`](../../1.bootstrap/network.md)
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [1.bootstrap/README.md](../../1.bootstrap/README.md)
+- [4.apps/README.md](../../4.apps/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/ssot/alerting.md](./alerting.md)
+- [docs/ssot/env.md](./env.md)
+- [docs/ssot/observability.md](./observability.md)

--- a/docs/ssot/observability.md
+++ b/docs/ssot/observability.md
@@ -35,6 +35,7 @@
 | SigNoz UI | `https://signoz.<internal_domain>` | 通过 Cloudflare proxy + cert-manager |
 
 > 域名 SSOT 见 `docs/ssot/network.md`。
+> 告警 SSOT 见 `docs/ssot/alerting.md`。
 
 ## 接入规范（Apps → OTel）
 
@@ -61,3 +62,10 @@
 - 选型：`docs/project/BRN-004.md`
 - Feature flags：`docs/ssot/vars.md`
 - 域名规则：`docs/ssot/network.md`
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [docs/ssot/alerting.md](./alerting.md)

--- a/docs/ssot/pipeline.md
+++ b/docs/ssot/pipeline.md
@@ -366,3 +366,18 @@ git push
 | `1.bootstrap/2.atlantis.tf` | Atlantis 部署定义 |
 | `docs/ssot/secrets.md` | 密钥管理 |
 | `docs/ssot/vars.md` | 变量定义 |
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [0.check_now.md](../../0.check_now.md)
+- [README.md](../../README.md)
+- [.github/README.md](../../.github/README.md)
+- [.github/workflows/README.md](../../.github/workflows/README.md)
+- [4.apps/README.md](../../4.apps/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/change_log/2025-12-15.infra_flash_per_commit.md](../change_log/2025-12-15.infra_flash_per_commit.md)
+- [docs/change_log/2025-12-15.pipeline_simplify_scheme_a.md](../change_log/2025-12-15.pipeline_simplify_scheme_a.md)
+- [docs/ssot/dir.md](./dir.md)

--- a/docs/ssot/secrets.md
+++ b/docs/ssot/secrets.md
@@ -57,6 +57,8 @@ graph LR
 |--------|------|------|
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code 集成 | 单独管理 |
 
+AI 接入相关的变量/密钥与注入方式见：`docs/ssot/ai.md`。
+
 ---
 
 ## 同步命令
@@ -117,3 +119,13 @@ done
 - **1Password 仅存根密钥**（Atlantis 登录、Vault root token、Casdoor 管理密码），作为离线恢复源，不再做日常运维依赖。
 - **Vault 作为主库**：所有运行时凭据、Casdoor client secret、Webhook Token、Terraform `random_password` 等都优先写入 Vault，再由 Agent 注入或同步到 CI 环境，避免在 1Password 里频繁复制粘贴。
 - **Fallback 设计**：当需要同时保留 1Password 与 Vault 副本时，Vault 为 SSOT、1Password 仅做 backup（“Vault-first, 1Password fallback”），确保可以实现“1Password 0 依赖”或将全部凭据迁移到 Vault 的两条路径。
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [.github/workflows/README.md](../../.github/workflows/README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/ssot/ai.md](./ai.md)
+- [docs/ssot/pipeline.md](./pipeline.md)

--- a/docs/ssot/storage.md
+++ b/docs/ssot/storage.md
@@ -58,3 +58,12 @@
 - 存储类：`docs/ssot/k3s.md`
 - 数据落点：`docs/ssot/db.md`
 - R2 backend：`1.bootstrap/backend.tf`
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [1.bootstrap/README.md](../../1.bootstrap/README.md)
+- [2.platform/README.md](../../2.platform/README.md)
+- [3.data/README.md](../../3.data/README.md)

--- a/docs/ssot/vars.md
+++ b/docs/ssot/vars.md
@@ -43,3 +43,13 @@
 
 - L1 Bootstrap: [`1.bootstrap/variables.tf`](../../1.bootstrap/variables.tf)
 - L2 Platform: [`2.platform/variables.tf`](../../2.platform/variables.tf)
+
+---
+
+## Used by（反向链接）
+
+- [docs/ssot/README.md](./README.md)
+- [docs/project/BRN-008.md](../project/BRN-008.md)
+- [docs/ssot/env.md](./env.md)
+- [docs/ssot/observability.md](./observability.md)
+- [docs/ssot/pipeline.md](./pipeline.md)

--- a/project/BRN-004.md
+++ b/project/BRN-004.md
@@ -1,0 +1,5 @@
+# BRN-004（入口）
+
+本文件用于稳定链接与兼容历史引用。BRN-004 的权威版本在：
+
+- [`docs/project/BRN-004.md`](../docs/project/BRN-004.md)

--- a/project/README.md
+++ b/project/README.md
@@ -1,0 +1,12 @@
+# Project（入口）
+
+> 兼容入口：`AGENTS.md` 约定 `project/README.md` 作为 TODO/计划入口。  
+> **实施状态 SSOT** 位于：[`docs/project/README.md`](../docs/project/README.md)。
+
+- ✅ **SSOT（实施状态）**：[`docs/project/README.md`](../docs/project/README.md)
+- 📌 **BRN 列表**：[`docs/project/`](../docs/project/)
+- 🧭 **当前上下文**：[`0.check_now.md`](../0.check_now.md)
+
+## 约定
+
+- 保持本文件极简：只做入口与导航，不重复 SSOT 内容。

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,13 @@
+# tools
+
+本目录放置**轻量脚本**（CI/本地校验用），不属于 Terraform layer（`0.tools/1.bootstrap/...`）。
+
+## `check_images.py`
+
+用途：预先校验 Docker Hub 上的镜像 tag 是否存在，避免部署时出现 `ImagePullBackOff` 才发现问题。
+
+```bash
+python3 tools/check_images.py nginx:1.27 postgres:16
+```
+
+> 需要联网访问 `auth.docker.io` 与 `registry-1.docker.io`。


### PR DESCRIPTION
## What
- 新增稳定入口（redirect）：`docs/dir.md`、`project/README.md`、`docs/BRN-004.env_eaas_design.md`
- SSOT 页面统一补齐 `Used by（反向链接）`，形成双向链接
- 修复/规范少量链接与口径（如 L3 namespace 统一为 `data-<env>`、修正失效文件引用）
- 补齐 `tools/README.md`（目录自说明）

## Why
- SSOT 信息一处定型，其他文档只引用，减少漂移；同时保留旧路径入口避免 404（Wikipedia-style redirect + what-links-here）。

## Verify
- 本地扫描全仓库 Markdown 本地链接：无 missing。

## Notes
- 未改动 `AGENTS.md`（仅追加其它文档/入口/反链）。
