### PR TITLE
fix(ci): skip L4 Apply if no .tf files present

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -450,6 +450,12 @@ jobs:
         env:
           TF_LOG: INFO
         run: |
+          # Skip if no .tf files present (L4 is placeholder until apps are added)
+          if ! ls *.tf 1> /dev/null 2>&1; then
+            echo "⏭️ Skipping L4 Apply: No .tf files in 4.apps/"
+            exit 0
+          fi
+          
           terraform workspace select prod || terraform workspace new prod
           terraform apply -auto-approve || {
              echo "::error::L4 Apps Apply failed."


### PR DESCRIPTION
## Problem

`4.apps/` directory currently only has `README.md`, no `.tf` files.

This causes CI to fail with:
```
Error: No configuration files
Apply requires configuration to be present.
```

This was the **real cause** of #230 and #232 failures (after #231 SSO fix merged).

## Fix

Check for `.tf` files before running `terraform apply`: 
```bash
if ! ls *.tf 1> /dev/null 2>&1; then
  echo "⏭️ Skipping L4 Apply: No .tf files"
  exit 0
fi
```

## CI Failure Analysis

| Run | Root Cause | Fix |
|-----|------------|-----|
| Up to #229 | Vault HTML (SSO Gate) | ✅ PR #231 |
| #230, #232 | L4 no .tf files | ✅ **This PR** |