### PR TITLE
fix(ci): trigger on all TF layers, not just L1

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches: [main]
     paths:
+      # Trigger on infrastructure code changes (all layers)
       - "1.bootstrap/**"
+      - "2.platform/**"
+      - "3.data/**"
+      - "4.apps/**"
       - ".github/workflows/deploy-k3s.yml"
       - ".github/actions/**"
+      # Excluded: docs/** and *.md (no infra changes)
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
## Problem

The `deploy-k3s.yml` workflow only triggered on `1.bootstrap/**` changes.
This means L2/L3/L4 changes didn't trigger post-merge CI!

## Fix

Added all TF layer paths:
```yaml
paths:
  - "1.bootstrap/**"
  - "2.platform/**"   # NEW
  - "3.data/**"       # NEW
  - "4.apps/**"       # NEW
  - ".github/workflows/deploy-k3s.yml"
  - ".github/actions/**"
```

## Impact

This explains 6+ missing CI runs in last 40 commits:
- #223, #218, #221, etc. had no CI because they were L2/L3 only