### PR TITLE
fix(ci): pass internal_domain to L4 terraform-setup

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -448,6 +448,7 @@ jobs:
           cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           base_domain: ${{ secrets.BASE_DOMAIN }}
+          internal_domain: ${{ secrets.INTERNAL_DOMAIN }}
           vault_root_token: ${{ secrets.VAULT_ROOT_TOKEN }}
           vault_address: https://secrets.${{ secrets.INTERNAL_DOMAIN }}
 

--- a/0.tools/README.md
+++ b/0.tools/README.md
@@ -39,3 +39,4 @@ python3 0.tools/check_images.py nginx:1.27 postgres:16
 ```
 
 > Requires internet access to `auth.docker.io` and `registry-1.docker.io`.# CI Path Fix
+# Test per-commit comments


### PR DESCRIPTION
Testing that each commit gets its own infra-flash comment with marker `<!-- infra-flash-commit:SHA -->`