### PR TITLE
fix(ci): create skeleton comment before running checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,32 +46,57 @@ PR 创建/更新
 
 ### infra-flash 评论（Per-Commit）
 
-- PR 中**每个 commit**都会生成独立评论：`<!-- infra-flash-commit:abc1234 -->`
-- 评论包含 CI 表格、失败时的修复命令、以及下一步动作（例如 review plan 后 `atlantis apply`）
-- 新 commit push 不会覆盖旧评论，形成完整审计链
+**流程**：
+1. **骨架创建**：CI 开始时立即创建评论，锁定 commit
+2. **CI 结果更新**：检查完成后更新评论（通过=简洁，失败=详细表格）
+3. **触发 Atlantis**：CI 通过后自动评论 `atlantis plan`
+4. **追加 Plan/Apply**：`infra-flash-update.yml` 追加 Atlantis 操作到评论
+
+**评论结构**：
 
 ```markdown
 <!-- infra-flash-commit:abc1234 -->
 ## ⚡ Commit `abc1234`
 
-### CI Validate ✅ | 12:30 UTC
+<details><summary>📖 Commands</summary>
+| Command | Description |
+| `atlantis plan` | Re-run plan |
+| `atlantis apply` | Apply changes |
+| `atlantis unlock` | Unlock PR |
+</details>
 
-| Layer | Format | Lint | Validate |
-|:------|:------:|:----:|:--------:|
-| L1 Bootstrap | ✅ | ✅ | ✅ |
-| L2 Platform | ✅ | ✅ | ✅ |
-| L3 Data | ✅ | ⏭️ | ⏭️ |
+---
 
-⏳ **Atlantis autoplan** will run automatically. After plan is posted, review it then comment `atlantis apply`.
+### CI Validate ✅ | [abc1234](ci-run-link) | 12:30 UTC
+
+---
+
+### Atlantis Actions
+
+| Action | Trigger | Status | Output | Time |
+|:-------|:--------|:------:|:-------|:-----|
+| Plan | [CI #12345](ci-link) | ✅ | [output](link) | 12:31 UTC |
+| Apply | [@user #67890](link) | ✅ | [output](link) | 12:35 UTC |
+
+---
+
+✅ **Ready to merge!**
 ```
 
-### Atlantis（本仓库开启 autoplan）
+**Trigger 格式**：
+- `[CI #run-id](ci-run-link)` - CI 自动触发
+- `[@username #comment-id](comment-link)` - 人类评论触发
 
-本仓库 `atlantis.yaml` 将 `autoplan.enabled=true`，因此每次 PR 更新（push 新 commit）都会自动触发 `atlantis plan`：
-- Plan：Atlantis 自动评论 plan，并由 `infra-flash-update.yml` 追加状态到对应 commit 的 infra-flash 评论
-- Apply：仍需人工 review plan 后评论 `atlantis apply`
-  
-`atlantis plan` 仍可用于失败后的手动重试。
+### Atlantis（CI 触发 Plan）
+
+本仓库的 `atlantis.yaml` 配置了 `autoplan.enabled=false`。Plan 由 CI workflow 触发：
+
+1. CI 检查通过后，`terraform-plan.yml` 自动评论 `atlantis plan`
+2. Atlantis 执行 plan，发布结果评论
+3. `infra-flash-update.yml` 追加 Plan 状态到 commit 评论
+4. 用户 review plan 后评论 `atlantis apply`
+
+这避免了竞态条件：CI 评论在 Atlantis 运行前已存在。
 
 ---
 

--- a/.github/workflows/infra-flash-update.yml
+++ b/.github/workflows/infra-flash-update.yml
@@ -71,16 +71,14 @@ jobs:
               per_page: 100
             });
             
-            // 找到触发此操作的人类评论
+            // 找到触发此操作的评论（人类或 bot）
             const atlantisCommentTime = new Date(context.payload.comment.created_at);
             const triggerComment = comments
-              .filter(c => c.user?.type !== 'Bot')
               .filter(c => new Date(c.created_at) < atlantisCommentTime)
               .filter(c => (c.body || '').toLowerCase().includes(`atlantis ${stage.toLowerCase()}`))
               .pop();
             
-            const triggerUrl = triggerComment ? triggerComment.html_url : null;
-            const triggeredBy = triggerComment ? `@${triggerComment.user.login}` : 'autoplan';
+            const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
             
             // Find infra-flash comment for CURRENT commit using per-commit marker
             const MARKER = `<!-- infra-flash-commit:${currentSha} -->`;
@@ -110,12 +108,30 @@ jobs:
             let updatedBody = flashComment.body
               .replace(/\n*👉 \*\*Next:\*\*.*/g, '')
               .replace(/\n*✅ \*\*Ready to merge!\*\*/g, '')
-              .replace(/\n*⏳ \*\*Atlantis autoplan\*\*.*/g, '');
+              .replace(/\n*⏳ \*\*Triggering Atlantis plan\.\.\.\*\*/g, '')
+              .replace(/\n*❌ \*\*CI failed\.\*\*.*/g, '');
             
-            // 构建触发链接 (显示: 谁触发 → Atlantis输出)
-            const triggerLink = triggerUrl
-              ? `[${triggeredBy}](${triggerUrl})`
-              : triggeredBy;
+            // 构建触发链接
+            // 格式: [CI #run-id](ci-link) 或 [@user #comment-id](comment-link)
+            let triggerLink;
+            if (triggerComment) {
+              // 检查是否有 CI trigger 标记
+              const ciMatch = triggerComment.body.match(/<!-- ci-trigger:(\d+) -->/);
+              if (ciMatch) {
+                // CI 触发：链接到 CI run
+                const runId = ciMatch[1];
+                const ciUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
+                triggerLink = `[CI #${runId}](${ciUrl})`;
+              } else {
+                // 人类或 bot 评论触发
+                const commentId = triggerComment.id;
+                const username = triggerComment.user.login.replace('[bot]', '');
+                triggerLink = `[@${username} #${commentId}](${triggerComment.html_url})`;
+              }
+            } else {
+              // 没找到触发评论，用 PR 链接
+              triggerLink = `[@infra-flash](${prUrl})`;
+            }
             const outputLink = `[output](${atlantisCommentUrl})`;
             
             // 构建新操作记录行

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -8,7 +8,6 @@ on:
       - "2.platform/**"
       - "3.data/**"
       - "4.apps/**"
-      - "4.apps/**"
       - ".github/workflows/**"
 
 # Cancel in-progress runs for same PR
@@ -33,7 +32,105 @@ jobs:
         uses: actions/checkout@v4
 
       # ============================================================
-      # Setup Terraform
+      # STEP 1: Create skeleton comment FIRST (lock commit)
+      # ============================================================
+      - name: Generate App Token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ATLANTIS_GH_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
+
+      - name: Create skeleton comment
+        id: skeleton
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          result-encoding: string
+          script: |
+            const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 7);
+            const timestamp = new Date().toISOString().slice(11, 16) + ' UTC';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
+            const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`;
+            const MARKER = `<!-- infra-flash-commit:${sha} -->`;
+            
+            // Check if comment already exists
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100
+            });
+            const existing = comments.data.find(c => c.body.includes(MARKER));
+            
+            // Full skeleton with all sections
+            const skeleton = [
+              MARKER,
+              `## ⚡ Commit \`${sha}\``,
+              '',
+              '<details><summary>📖 Commands</summary>',
+              '',
+              '| Command | Description |',
+              '|:--------|:------------|',
+              '| `atlantis plan` | Re-run plan |',
+              '| `atlantis apply` | Apply changes |',
+              '| `atlantis unlock` | Unlock PR |',
+              '',
+              '</details>',
+              '',
+              '---',
+              '',
+              `### CI Validate ⏳ | [${sha}](${runUrl}) | ${timestamp}`,
+              '',
+              '⏳ Running checks...',
+              '',
+              '---',
+              '',
+              '### Atlantis Actions',
+              '',
+              '<!-- atlantis-actions -->',
+              '| Action | Trigger | Status | Output | Time |',
+              '|:-------|:--------|:------:|:-------|:-----|',
+              '<!-- /atlantis-actions -->',
+              '',
+              '---',
+              '',
+              '⏳ **Waiting for CI...**'
+            ].join('\n');
+            
+            let commentId;
+            if (existing) {
+              // Preserve existing Atlantis action rows
+              let body = skeleton;
+              const actionsMatch = existing.body.match(/<!-- atlantis-actions -->([\s\S]*?)<!-- \/atlantis-actions -->/);
+              if (actionsMatch && actionsMatch[1].trim()) {
+                body = skeleton.replace(
+                  /<!-- atlantis-actions -->\n\| Action[\s\S]*?<!-- \/atlantis-actions -->/,
+                  `<!-- atlantis-actions -->\n| Action | Trigger | Status | Output | Time |\n|:-------|:--------|:------:|:-------|:-----|${actionsMatch[1]}<!-- /atlantis-actions -->`
+                );
+              }
+              
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+              commentId = existing.id;
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: skeleton
+              });
+              commentId = created.data.id;
+            }
+            console.log(`Created/updated skeleton for commit ${sha}`);
+            return commentId.toString();
+
+      # ============================================================
+      # STEP 2: Run CI Checks
       # ============================================================
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
@@ -41,9 +138,6 @@ jobs:
           terraform_version: 1.6.6
           terraform_wrapper: false
 
-      # ============================================================
-      # Static Analysis (all layers)
-      # ============================================================
       - name: Format Check
         id: fmt
         run: terraform fmt -check -recursive -diff
@@ -83,9 +177,6 @@ jobs:
           chmod +x 0.tools/preflight-check.sh
           0.tools/preflight-check.sh
 
-      # ============================================================
-      # Terraform Validation (syntax-only: no backend / no remote services)
-      # ============================================================
       - name: Validate (L1)
         id: validate_l1
         working-directory: 1.bootstrap
@@ -111,17 +202,9 @@ jobs:
         continue-on-error: true
 
       # ============================================================
-      # infra-flash Comment (Single comment per PR, updated on each commit)
+      # STEP 3: Update comment with results
       # ============================================================
-      - name: Generate App Token
-        if: always()
-        id: app_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.ATLANTIS_GH_APP_ID }}
-          private-key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
-
-      - name: Update infra-flash comment
+      - name: Update comment with results
         if: always()
         uses: actions/github-script@v7
         with:
@@ -143,78 +226,131 @@ jobs:
             const sha = '${{ github.event.pull_request.head.sha }}'.substring(0, 7);
             const timestamp = new Date().toISOString().slice(11, 16) + ' UTC';
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
-            
-            const nextStep = allPass
-              ? '⏳ **Atlantis autoplan** will run automatically. After plan is posted, review it then comment `atlantis apply`.'
-              : '👉 **Next:** Fix errors locally, then `git push`';
-            
-            const fixCmd = '```bash\n# Fix locally:\nterraform fmt -recursive\nterraform validate\ngit push\n```';
-            
-            // Per-commit marker (unique per commit SHA)
+            const commentId = ${{ steps.skeleton.outputs.result }};
             const MARKER = `<!-- infra-flash-commit:${sha} -->`;
             
-            const comments = await github.rest.issues.listComments({
+            // Get existing comment
+            const existingComment = await github.rest.issues.getComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              per_page: 100
+              comment_id: commentId
             });
             
-            // Check if comment for THIS commit already exists
-            const existing = comments.data.find(c => c.body.includes(MARKER));
+            // CI section: simple if passed, detailed if failed
+            let ciSection;
+            if (allPass) {
+              ciSection = `### CI Validate ✅ | [${sha}](${runUrl}) | ${timestamp}`;
+            } else {
+              const fixCmd = '```bash\n# Fix locally:\nterraform fmt -recursive\nterraform validate\ngit push\n```';
+              ciSection = [
+                `### CI Validate ❌ | [${sha}](${runUrl}) | ${timestamp}`,
+                '',
+                '| Layer | Format | Lint | Validate |',
+                '|:------|:------:|:----:|:--------:|',
+                `| L1 Bootstrap | ${icon(fmt)} | ${icon(lint_l1)} | ${icon(validate_l1)} |`,
+                `| L2 Platform | ${icon(fmt)} | ${icon(lint_l2)} | ${icon(validate_l2)} |`,
+                `| L3 Data | ${icon(fmt)} | ${icon(lint_l3)} | ${icon(validate_l3)} |`,
+                `| L4 Apps | ${icon(fmt)} | ${icon(lint_l4)} | ${icon(validate_l4)} |`,
+                '',
+                fixCmd
+              ].join('\n');
+            }
             
-            // Build CI status section
-            const ciSection = [
-              `### CI Validate ${allPass ? '✅' : '❌'} | [${sha}](${runUrl}) | ${timestamp}`,
-              '',
-              '| Layer | Format | Lint | Validate |',
-              '|:------|:------:|:----:|:--------:|',
-              `| L1 Bootstrap | ${icon(fmt)} | ${icon(lint_l1)} | ${icon(validate_l1)} |`,
-              `| L2 Platform | ${icon(fmt)} | ${icon(lint_l2)} | ${icon(validate_l2)} |`,
-              `| L3 Data | ${icon(fmt)} | ${icon(lint_l3)} | ${icon(validate_l3)} |`,
-              `| L4 Apps | ${icon(fmt)} | ${icon(lint_l4)} | ${icon(validate_l4)} |`,
-              '',
-              !allPass ? fixCmd : ''
+            // Next step
+            const nextStep = allPass
+              ? '⏳ **Triggering Atlantis plan...**'
+              : '❌ **CI failed.** Fix errors and push again.';
+            
+            // Preserve Atlantis actions
+            let atlantisSection = [
+              '<!-- atlantis-actions -->',
+              '| Action | Trigger | Status | Output | Time |',
+              '|:-------|:--------|:------:|:-------|:-----|',
+              '<!-- /atlantis-actions -->'
             ].join('\n');
             
+            const actionsMatch = existingComment.data.body.match(/<!-- atlantis-actions -->([\s\S]*?)<!-- \/atlantis-actions -->/);
+            if (actionsMatch && actionsMatch[1].includes('|')) {
+              atlantisSection = `<!-- atlantis-actions -->${actionsMatch[1]}<!-- /atlantis-actions -->`;
+            }
+            
+            // Build final body
             const body = [
               MARKER,
               `## ⚡ Commit \`${sha}\``,
               '',
+              '<details><summary>📖 Commands</summary>',
+              '',
+              '| Command | Description |',
+              '|:--------|:------------|',
+              '| `atlantis plan` | Re-run plan |',
+              '| `atlantis apply` | Apply changes |',
+              '| `atlantis unlock` | Unlock PR |',
+              '',
+              '</details>',
+              '',
+              '---',
+              '',
               ciSection,
+              '',
+              '---',
+              '',
+              '### Atlantis Actions',
+              '',
+              atlantisSection,
+              '',
+              '---',
               '',
               nextStep
             ].join('\n');
             
-            if (existing) {
-              // Update existing comment for this commit (CI re-run case)
-              // Preserve Atlantis sections if any
-              let updatedBody = body;
-              const atlantisMatch = existing.body.match(/(---\n### Atlantis[\s\S]*)/);
-              if (atlantisMatch) {
-                updatedBody = body.replace(/⏳ \*\*Atlantis.*/, '') + '\n\n' + atlantisMatch[1];
-              }
-              
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: updatedBody
-              });
-              console.log(`Updated existing comment for commit ${sha}`);
-            } else {
-              // Create NEW comment for this commit
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-              console.log(`Created new comment for commit ${sha}`);
-            }
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+              body: body
+            });
+            console.log(`Updated comment: CI ${allPass ? 'PASS' : 'FAIL'}`);
 
       # ============================================================
-      # Final Status (fail if any check failed)
+      # STEP 4: Trigger Atlantis plan (if all checks passed)
+      # ============================================================
+      - name: Trigger Atlantis Plan
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const fmt = '${{ steps.fmt.outcome }}';
+            const lint_l1 = '${{ steps.lint_l1.outcome }}';
+            const lint_l2 = '${{ steps.lint_l2.outcome }}';
+            const lint_l3 = '${{ steps.lint_l3.outcome }}';
+            const lint_l4 = '${{ steps.lint_l4.outcome }}';
+            const validate_l1 = '${{ steps.validate_l1.outcome }}';
+            const validate_l2 = '${{ steps.validate_l2.outcome }}';
+            const validate_l3 = '${{ steps.validate_l3.outcome }}';
+            const validate_l4 = '${{ steps.validate_l4.outcome }}';
+            
+            const allPass = [fmt, lint_l1, lint_l2, lint_l3, lint_l4, validate_l1, validate_l2, validate_l3, validate_l4]
+              .every(s => s === 'success' || s === 'skipped');
+            
+            if (!allPass) {
+              console.log('CI failed, skipping Atlantis');
+              return;
+            }
+            
+            // Include CI run ID in comment for traceability
+            const runId = '${{ github.run_id }}';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `atlantis plan\n<!-- ci-trigger:${runId} -->`
+            });
+            console.log('Triggered Atlantis plan');
+
+      # ============================================================
+      # Final Status
       # ============================================================
       - name: Check Results
         run: |

--- a/0.check_now.md
+++ b/0.check_now.md
@@ -1,37 +1,41 @@
 # 0.check_now.md
 
 ## 1. What (Target)
-Simplify CI ↔ Atlantis to Scheme A while keeping infra-flash per-commit audit: CI only does static checks; Atlantis autoplan does plan/apply; infra-flash appends plan/apply to the matching commit comment reliably.
+Per-commit comment system with full traceability: CI creates comment → runs checks → triggers Atlantis plan → comment updated with Plan/Apply status.
 
 ## 2. Why (Value)
-Reduce cognitive load and PR noise: one execution path for plan/apply (Atlantis), one execution path for syntax checks (CI), and a per-commit comment stream that stays correctly attributed for audits and rollback/debugging.
+- **No race condition**: Comment exists before Atlantis runs
+- **CI failure blocks Atlantis**: Saves compute, prevents deploying bad code
+- **Full audit trail**: Every action (CI/Plan/Apply) has clickable link to source
 
 ## 3. Where (Location)
-- Automation: `atlantis.yaml`, `.github/workflows/terraform-plan.yml`, `.github/workflows/infra-flash-update.yml`, `.github/workflows/deploy-k3s.yml`
-- Scripts: `0.tools/preflight-check.sh`
-- Docs: `.github/workflows/README.md`, `.github/README.md`, `README.md`, `docs/ssot/ops.pipeline.md`, `docs/ssot/README.md`
-- History: `docs/change_log/`
+- Workflows: `.github/workflows/terraform-plan.yml`, `.github/workflows/infra-flash-update.yml`
+- Docs: `.github/workflows/README.md`
 
 ## 4. Who (Owner)
-Infra Platform / AI Assistant (acting CTO view for review simplicity & architecture fitness).
+Infra Platform / AI Assistant
 
 ## 5. When (Timeline)
-Dec 15 window → implement Scheme A simplification + reduce redundant pipelines.
+Dec 17 - Implementing and verifying new flow.
 
 ## 6. How (Action Plan)
 
 ### Implementation Steps
-- [x] CI runs static checks only (fmt/tflint/validate), and posts per-commit infra-flash comments.
-- [x] Atlantis autoplan runs on PR updates; plan/apply results append to the matching infra-flash comment.
-- [x] Add `infra-flash-commit:xxxxxxx` marker into Atlantis output for robust comment mapping.
-- [x] Trim `deploy-k3s.yml` to L1 Bootstrap only (L2+ handled via Atlantis).
-- [x] Refresh SSOT docs and this 5W1H.
+- [x] CI creates skeleton comment at start (locks commit)
+- [x] CI updates comment with results (pass=simple, fail=details)
+- [x] CI triggers `atlantis plan` via comment if passed
+- [x] `infra-flash-update.yml` appends Plan/Apply to commit comment
+- [x] Trigger links: `[CI #run-id](link)`, `[@user #comment-id](link)`
+- [x] Update `.github/workflows/README.md` to reflect new flow
 
 ### Verification Checklist
-- [ ] Create a smoke PR and push 2 commits ⇒ confirm two infra-flash comments exist (each scoped to its SHA).
-- [ ] Wait for Atlantis autoplan ⇒ verify it appends `### Atlantis Plan ...` to the matching commit comment (commit match via `infra-flash-commit:` marker).
-- [ ] Comment `atlantis apply` ⇒ verify it appends `### Atlantis Apply ...` and shows `✅ Ready to merge!`.
-- [ ] Push a new commit after a Plan failure ⇒ verify new commit gets a new infra-flash comment and new autoplan result appends to the new one.
+- [ ] PR push → skeleton comment created with ⏳
+- [ ] CI completes → comment updated with ✅ or ❌
+- [ ] CI triggers `atlantis plan` comment
+- [ ] Atlantis Plan → appended to comment with `[CI #run-id](ci-link)`
+- [ ] Human `atlantis apply` → appended with `[@user #id](comment-link)`
+- [ ] Final state: `✅ Ready to merge!`
 
-### Follow-ups / Notes
-- Dogfood on an internal PR; if Atlantis output truncation hides the marker, move the marker to an even earlier plan/apply step.
+### Follow-ups
+- After merge, test with real terraform change PR to verify full E2E flow
+- `infra-flash-update.yml` changes only take effect after merge (issue_comment reads from main)


### PR DESCRIPTION
## Problem
Race condition: Atlantis autoplan could finish before CI created its comment, causing `infra-flash-update.yml` to fail with `No infra-flash comment found`.

## Solution
New flow:
1. **Create skeleton comment immediately** (`⏳ running...`)
2. Run all CI checks (format, lint, validate)
3. **Update comment with results** (`✅/❌`)
4. **If passed, trigger Atlantis plan** via comment

## Benefits
- ✅ Comment exists before Atlantis runs
- ✅ No race condition
- ✅ CI failure blocks Atlantis (saves compute)
- ✅ Clean audit trail: `CI → Plan → Apply`

## Expected Comment Lifecycle
```
Push → Comment created: ⏳ CI running...
       ↓
       CI finishes → Comment updated with results
       ↓ (if passed)
       Atlantis plan triggered → Plan appended to comment
       ↓
       User: atlantis apply → Apply appended to comment
       ↓
       ✅ Ready to merge!
```