### PR TITLE
fix(ci): keep CI logs clean

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -131,6 +131,9 @@ Atlantis 评论 "Ran Plan for..."
 
 用于 bootstrap/恢复：按顺序 apply L1→L2→L3→L4（当前 L3/L4 的 apply/verify 仅在 `push` 事件执行；`workflow_dispatch` 会跳过这些 step）。
 
+日志策略：
+- 默认不启用 `TF_LOG`（避免 Terraform Provider 的噪音日志污染 CI 输出）；需要排障时再在本地或手动执行时显式开启。
+
 一致性策略：
 - workflow 会尝试 `terraform import` 把已存在的资源纳入 state 管理（例如 `helm_release.atlantis`）。
 - 为修复 Helm `cannot re-use a name` 这类“集群残留但 state 缺失”的冲突，当前会清理 `platform` 命名空间下 Atlantis 的 Helm release secrets（按 `sh.helm.release.v1.atlantis*` 模式匹配），并删除相关 `deployment/svc/statefulset`（见 `Import Existing Resources` step）。

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -204,8 +204,6 @@ jobs:
       # =========================================================
       - name: Apply Infrastructure (L1)
         working-directory: 1.bootstrap
-        env:
-          TF_LOG: INFO
         run: |
           terraform apply -auto-approve || {
             echo "::error::L1 Apply failed. Checking pod status..."
@@ -309,8 +307,6 @@ jobs:
 
       - name: Apply Infrastructure (L2 - Platform)
         working-directory: 2.platform
-        env:
-          TF_LOG: INFO
         run: |
           # Ensure platform workspace is default
           terraform workspace select default || terraform workspace new default
@@ -367,8 +363,6 @@ jobs:
       - name: Apply Infrastructure (L3 - Data)
         if: github.event_name == 'push'
         working-directory: 3.data
-        env:
-          TF_LOG: INFO
         run: |
           # Use workspace based on branch mapping (main -> prod)
           terraform workspace select prod || terraform workspace new prod
@@ -403,7 +397,7 @@ jobs:
           kubectl exec -n $NS postgresql-0 -- pg_isready -U postgres && echo "✅ PostgreSQL: Ready" || echo "❌ PostgreSQL: Not Ready"
           
           echo "Checking Redis..."
-          kubectl exec -n $NS redis-master-0 -- redis-cli -a "$REDIS_PASS" ping && echo "✅ Redis: PONG" || echo "❌ Redis: Not Ready"
+          kubectl exec -n $NS redis-master-0 -- env REDISCLI_AUTH="$REDIS_PASS" redis-cli ping && echo "✅ Redis: PONG" || echo "❌ Redis: Not Ready"
           
           echo "Checking ClickHouse..."
           kubectl exec -n $NS clickhouse-shard0-0 -- clickhouse-client --user default --password "$CH_PASS" --query "SELECT 1" && echo "✅ ClickHouse: Ready" || echo "❌ ClickHouse: Not Ready"
@@ -456,7 +450,6 @@ jobs:
         if: github.event_name == 'push'
         working-directory: 4.apps
         env:
-          TF_LOG: INFO
           TF_VAR_environment: prod
         run: |
           # Skip if no .tf files present (L4 is placeholder until apps are added)

--- a/docs/ssot/README.md
+++ b/docs/ssot/README.md
@@ -21,7 +21,7 @@
 | 文件 | 核心问题 | 关键内容 |
 |------|----------|----------|
 | [platform.auth.md](./platform.auth.md) | 统一认证 | Casdoor SSO 门户覆盖、GitHub OAuth 自动化、验证命令 |
-| [platform.network.md](./platform.network.md) | 域名规则 | Internal vs Env 模式 |
+| [platform.network.md](./platform.network.md) | 域名规则 | Internal vs Env 模式（环境模型见 `core.env.md`） |
 | [platform.secrets.md](./platform.secrets.md) | 密钥管理 | 四层模型、1Password 清单、Vault（SSOT） |
 | [platform.ai.md](./platform.ai.md) | AI 接入 | OpenRouter、变量/密钥、注入方式 |
 

--- a/docs/ssot/platform.network.md
+++ b/docs/ssot/platform.network.md
@@ -11,7 +11,7 @@
 | `x-<env>.<base_domain>` | ✅ Orange | 测试环境 | `x-staging.truealpha.club` |
 | `<base_domain>` | ✅ Orange | 生产 | `truealpha.club` |
 
-> 环境模型（workspace/state/namespace/domain 的统一规则）见：[`env.md`](./env.md)
+> 环境模型（workspace/state/namespace/domain 的统一规则）见：[`core.env.md`](./core.env.md)
 
 ## 服务域名映射
 
@@ -56,4 +56,3 @@ nginx.ingress.kubernetes.io/whitelist-source-range: "140.82.112.0/20,185.199.108
 - Network 详情: [`1.bootstrap/network.md`](../../1.bootstrap/network.md)
 
 ---
-

--- a/website/README.md
+++ b/website/README.md
@@ -28,5 +28,9 @@ This directory contains the configuration for the MkDocs static site generator.
 
 ## Directory Structure
 
-- `gen_pages.py`: Python script to generate the site structure (flattens `docs/` and pulls in root `README.md`).
+- `gen_pages.py`: Generates the MkDocs file tree from git-tracked `*.md` (including submodules), rewrites internal links to match the generated paths, and falls back to GitHub blob links for non-doc files.
 - `mkdocs.yml`: Main configuration file.
+
+Notes:
+- MkDocs ignores dot-directories by default; `.github/...` content is mapped to `github/...` in the generated site.
+- If you want `apps/` docs, run `git submodule update --init --recursive` before building.

--- a/website/gen_pages.py
+++ b/website/gen_pages.py
@@ -7,6 +7,7 @@ import re
 import os
 import json
 from collections import defaultdict
+from typing import NamedTuple, Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_PREFIX = Path(".")
@@ -33,6 +34,7 @@ EXTRA_STATIC_FILES = [
     Path("website/mkdocs.yml"),
     Path("website/requirements.txt"),
     Path(".github/workflows/docs-site.yml"),
+    Path(".github/workflows/readme-coverage.yml"),
 ]
 
 # Files to move from Root (or flattened Root) to "Overview/" folder to clean up navigation
@@ -48,13 +50,63 @@ def _write_text(dst: Path, text: str) -> None:
         f.write(text)
 
 # Store file content in memory for backlink processing
-processed_files = {}
+processed_files: dict[Path, str] = {}
+
+# Source → Dest mapping for link rewriting
+src_to_dst: dict[Path, Path] = {}
+src_to_content: dict[Path, str] = {}
 
 # Regex for H1 extraction
 title_pattern = re.compile(r'^#\s+(.*)', re.MULTILINE)
 
 # Map for Sidebar Tooltips: { "SidebarLabel": "Real Title" }
 SIDEBAR_TOOLTIPS = {}
+
+class RepoSpec(NamedTuple):
+    prefix: Path
+    repo_url: str
+    ref: str
+
+def _git_cmd(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+def _normalize_github_https(url: str) -> Optional[str]:
+    url = url.strip()
+    if not url:
+        return None
+
+    if url.startswith("git@github.com:"):
+        url = "https://github.com/" + url.removeprefix("git@github.com:")
+
+    if url.startswith("https://github.com/") and url.endswith(".git"):
+        url = url[:-4]
+
+    if url.startswith("http://github.com/"):
+        url = "https://github.com/" + url.removeprefix("http://github.com/")
+
+    if url.startswith("https://github.com/"):
+        return url
+
+    return None
+
+def _repo_spec(repo_root: Path, prefix: Path) -> Optional[RepoSpec]:
+    remote = _git_cmd(repo_root, ["config", "--get", "remote.origin.url"]).stdout.strip()
+    repo_url = _normalize_github_https(remote)
+    if not repo_url:
+        return None
+
+    ref = _git_cmd(repo_root, ["rev-parse", "HEAD"]).stdout.strip()
+    if not ref:
+        return None
+
+    return RepoSpec(prefix=prefix, repo_url=repo_url, ref=ref)
 
 def _git_ls_files(repo_root: Path, pattern: str) -> list[Path]:
     result = subprocess.run(
@@ -97,83 +149,149 @@ def _should_skip(rel_path: Path) -> bool:
         return True
     return False
 
-def _process_file_content(repo_root: Path, rel: Path, rel_prefix: Path = Path()):
-    src_path = repo_root / rel
-    
-    # Flattening Logic and Path Mapping
+def _map_path_for_site(rel: Path) -> Path:
+    if rel.parts and rel.parts[0] == ".github":
+        return Path("github") / Path(*rel.parts[1:])
+    return rel
+
+def _map_src_to_dst(rel: Path, rel_prefix: Path) -> Path:
+    if not rel.parts:
+        return rel_prefix / rel
+
     if rel.parts[0] == "docs":
-        # Flatten docs/ folder to root
-        if len(rel.parts) > 1:
-            dst_rel = Path(*rel.parts[1:])
-        else:
-            dst_rel = Path(rel.name)
-        
-        # Special handling for docs/README.md -> Overview/index.md
+        dst_rel = Path(*rel.parts[1:]) if len(rel.parts) > 1 else Path(rel.name)
         if dst_rel == Path("README.md"):
             dst_rel = Path("Overview/index.md")
     else:
         dst_rel = rel
-        # Map Root README.md to index.md
         if dst_rel == Path("README.md"):
             dst_rel = Path("index.md")
 
-    # Rename any other README.md to index.md to ensure folder pages work
     if dst_rel.name == "README.md" and dst_rel != Path("Overview/index.md"):
-         dst_rel = dst_rel.with_name("index.md")
+        dst_rel = dst_rel.with_name("index.md")
 
-    # Move specific loose files to Overview/
     if dst_rel.name in MOVED_TO_OVERVIEW:
         dst_rel = Path("Overview") / dst_rel
 
-    dst_rel = rel_prefix / dst_rel
+    return _map_path_for_site(rel_prefix / dst_rel)
 
-    if _should_skip(dst_rel) and not (rel.parts[0] == "docs"): 
+_FENCE_RE = re.compile(r"^(```|~~~)")
+_MD_LINK_RE = re.compile(r"(!?\[[^\]]*\])\(([^)\n]+)\)")
+
+def _strip_angle_brackets(url: str) -> str:
+    url = url.strip()
+    if url.startswith("<") and url.endswith(">") and len(url) >= 2:
+        return url[1:-1].strip()
+    return url
+
+def _relpath(from_dir: Path, to_path: Path) -> str:
+    return os.path.relpath(str(to_path), start=str(from_dir)).replace(os.sep, "/")
+
+def _resolve_repo_url(target_src: Path, repo_specs: list[RepoSpec]) -> Optional[RepoSpec]:
+    for spec in repo_specs:
+        if spec.prefix and target_src.parts[: len(spec.prefix.parts)] == spec.prefix.parts:
+            return spec
+    for spec in repo_specs:
+        if not spec.prefix.parts:
+            return spec
+    return None
+
+def _rewrite_links(
+    content: str,
+    *,
+    src_path: Path,
+    dst_path: Path,
+    repo_root: Path,
+    repo_specs: list[RepoSpec],
+    static_src_to_dst: dict[Path, Path],
+) -> str:
+    in_fence = False
+    fence = ""
+    out_lines: list[str] = []
+
+    def replace_match(match: re.Match[str]) -> str:
+        label = match.group(1)
+        raw = _strip_angle_brackets(match.group(2))
+
+        if not raw or raw.startswith("#") or "://" in raw or raw.startswith("mailto:"):
+            return match.group(0)
+
+        path_part, sep, fragment = raw.partition("#")
+        path_part = path_part.strip()
+        if not path_part:
+            return match.group(0)
+
+        # Preserve any title portion: (url "title")
+        url_token, *rest = path_part.split(maxsplit=1)
+        title_suffix = f" {rest[0]}" if rest else ""
+
+        # Resolve target relative to the *source* file location (repo layout).
+        normalized = Path(os.path.normpath(os.path.join(src_path.parent.as_posix(), url_token)))
+
+        # If the file doesn't exist, try a best-effort sibling match: X.md → X.*.md (unique).
+        abs_candidate = repo_root / normalized
+        if normalized.suffix == ".md" and not abs_candidate.exists():
+            parent = abs_candidate.parent
+            stem = abs_candidate.stem
+            candidates = sorted(parent.glob(f"{stem}.*.md")) if parent.exists() else []
+            if len(candidates) == 1:
+                normalized = candidates[0].relative_to(repo_root)
+
+        if normalized in src_to_dst:
+            target_dst = src_to_dst[normalized]
+            rel = _relpath(dst_path.parent, target_dst)
+            return f"{label}({rel}{sep}{fragment}{title_suffix})"
+
+        if normalized in static_src_to_dst:
+            rel = _relpath(dst_path.parent, static_src_to_dst[normalized])
+            return f"{label}({rel}{sep}{fragment}{title_suffix})"
+
+        # Fallback: link to GitHub blob (per-repo, pinned to current checkout ref).
+        spec = _resolve_repo_url(normalized, repo_specs)
+        if spec:
+            rel_in_repo = normalized
+            if spec.prefix.parts:
+                rel_in_repo = Path(*normalized.parts[len(spec.prefix.parts) :])
+            gh = f"{spec.repo_url}/blob/{spec.ref}/{rel_in_repo.as_posix()}"
+            return f"{label}({gh}{sep}{fragment}{title_suffix})"
+
+        return match.group(0)
+
+    for line in content.splitlines(keepends=True):
+        m = _FENCE_RE.match(line)
+        if m:
+            marker = m.group(1)
+            if not in_fence:
+                in_fence = True
+                fence = marker
+            elif fence == marker:
+                in_fence = False
+                fence = ""
+            out_lines.append(line)
+            continue
+
+        if in_fence:
+            out_lines.append(line)
+            continue
+
+        out_lines.append(_MD_LINK_RE.sub(replace_match, line))
+
+    return "".join(out_lines)
+
+def _register_file(repo_root: Path, rel: Path, rel_prefix: Path = Path()) -> None:
+    full_src = rel_prefix / rel
+    dst_rel = _map_src_to_dst(rel, rel_prefix)
+
+    if _should_skip(dst_rel):
         return
-        
-    content = src_path.read_text(encoding="utf-8")
-    
-    # Rewrite links to account for flattening and renaming
-    content = content.replace("docs/README.md", "Overview/index.md")
-    content = content.replace("](docs/", "](")
-    content = content.replace("](../docs/", "](../")
-    content = content.replace("](./docs/", "](./")
-    
-    for filename in MOVED_TO_OVERVIEW:
-        content = re.sub(r'(\(\]|\]\.|]\.|\.\.|\/)' + re.escape(filename) + r'(\)|\.md)', r'\1Overview/' + filename + r'\2', content)
 
-    content = content.replace("README.md", "index.md")
-    
-    # Process Title for Tooltip Mapping and Frontmatter
-    h1_title = "Untitled"
-    m = title_pattern.search(content)
-    if m:
-        h1_title = m.group(1).strip().replace('"', '\"') # Escape quotes for JS safety
-    
-    # 5. Sidebar Logic & Tooltips
-    sidebar_label = ""
-    # Case A: Standard File (not index.md)
-    if dst_rel.name != "index.md":
-        sidebar_label = dst_rel.stem
-        if not content.startswith("---"): # Inject frontmatter only if not already present
-            frontmatter = f"---\ntitle: {sidebar_label}\n---\n\n"
-            content = frontmatter + content
-    # Case B: Index File (Folder)
-    else:
-        if len(dst_rel.parts) > 1: # e.g., 1.bootstrap/index.md
-            sidebar_label = dst_rel.parts[-2] # Folder name (e.g., "1.bootstrap")
-        else: # Root index.md
-            sidebar_label = "Home" 
-            SIDEBAR_TOOLTIPS[REPO_ROOT.name] = h1_title 
-
-    if sidebar_label: # Add to tooltip map if we have a sidebar label
-        SIDEBAR_TOOLTIPS[sidebar_label] = h1_title
-    
-    processed_files[dst_rel] = content
+    src_to_dst[full_src] = dst_rel
+    src_to_content[full_src] = (repo_root / rel).read_text(encoding="utf-8")
 
 def _collect_files(repo_root: Path, rel_prefix: Path = Path()):
     for rel in sorted(_git_ls_files(repo_root, "*.md")):
         if (repo_root / rel).exists():
-            _process_file_content(repo_root, rel, rel_prefix)
+            _register_file(repo_root, rel, rel_prefix)
 
 # 1. Collect all content
 _collect_files(REPO_ROOT)
@@ -193,7 +311,57 @@ for sub_path in _git_submodule_paths(REPO_ROOT):
         continue
     _collect_files(sub_root, rel_prefix=sub_path)
 
-# 2. Analyze Backlinks
+# 2. Build repo specs for GitHub fallback
+repo_specs: list[RepoSpec] = []
+root_spec = _repo_spec(REPO_ROOT, prefix=Path())
+if root_spec:
+    repo_specs.append(root_spec)
+
+for sub_path in _git_submodule_paths(REPO_ROOT):
+    sub_root = REPO_ROOT / sub_path
+    spec = _repo_spec(sub_root, prefix=sub_path)
+    if spec:
+        repo_specs.append(spec)
+
+static_src_to_dst: dict[Path, Path] = {src: _map_path_for_site(src) for src in EXTRA_STATIC_FILES}
+
+# 3. Rewrite content and build tooltip map
+for src_path, dst_path in src_to_dst.items():
+    content = src_to_content[src_path]
+
+    # Process Title for Tooltip Mapping and Frontmatter
+    h1_title = "Untitled"
+    m = title_pattern.search(content)
+    if m:
+        h1_title = m.group(1).strip().replace('"', '\\"')
+
+    sidebar_label = ""
+    if dst_path.name != "index.md":
+        sidebar_label = dst_path.stem
+        if not content.startswith("---"):
+            content = f"---\ntitle: {sidebar_label}\n---\n\n{content}"
+    else:
+        if len(dst_path.parts) > 1:
+            sidebar_label = dst_path.parts[-2]
+        else:
+            sidebar_label = "Home"
+            SIDEBAR_TOOLTIPS[REPO_ROOT.name] = h1_title
+
+    if sidebar_label:
+        SIDEBAR_TOOLTIPS[sidebar_label] = h1_title
+
+    content = _rewrite_links(
+        content,
+        src_path=src_path,
+        dst_path=dst_path,
+        repo_root=REPO_ROOT,
+        repo_specs=repo_specs,
+        static_src_to_dst=static_src_to_dst,
+    )
+
+    processed_files[dst_path] = content
+
+# 4. Analyze Backlinks
 backlinks = defaultdict(list)
 link_pattern = re.compile(r'\[.*?\]\((.*?)\)')
 
@@ -201,7 +369,7 @@ def get_title(content):
     m = title_pattern.search(content)
     return m.group(1).strip() if m else "Untitled"
 
-for src_path, content in processed_files.items():
+for dst_path, content in processed_files.items():
     src_title = get_title(content)
     for match in link_pattern.finditer(content):
         link_target = match.group(1)
@@ -211,15 +379,15 @@ for src_path, content in processed_files.items():
         if not target_file:
             continue
         try:
-            src_dir = os.path.dirname(str(src_path))
+            src_dir = os.path.dirname(str(dst_path))
             norm_target = os.path.normpath(os.path.join(src_dir, target_file))
             target_path = Path(norm_target)
-            if target_path in processed_files and target_path != src_path:
-                backlinks[target_path].append((src_path, src_title))
+            if target_path in processed_files and target_path != dst_path:
+                backlinks[target_path].append((dst_path, src_title))
         except Exception:
             continue
 
-# 3. Write files
+# 5. Write files
 for path, content in processed_files.items():
     if path in backlinks:
         links = backlinks[path]
@@ -245,7 +413,7 @@ for path, content in processed_files.items():
     
     _write_text(OUTPUT_PREFIX / path, content)
 
-# 4. Generate Tooltip JS
+# 6. Generate Tooltip JS
 js_content = f"""
 document.addEventListener("DOMContentLoaded", function() {{
     var titles = {json.dumps(SIDEBAR_TOOLTIPS)};
@@ -264,10 +432,9 @@ document.addEventListener("DOMContentLoaded", function() {{
 """
 _write_text(OUTPUT_PREFIX / "js/titles.js", js_content)
 
-# 5. Copy extra static files
+# 7. Copy extra static files
 for rel in EXTRA_STATIC_FILES:
-    if _should_skip(rel):
+    src = REPO_ROOT / rel
+    if not src.exists():
         continue
-    if not (REPO_ROOT / rel).exists():
-        continue
-    _write_text(rel, (REPO_ROOT / rel).read_text(encoding="utf-8"))
+    _write_text(static_src_to_dst[rel], src.read_text(encoding="utf-8"))

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -28,6 +28,10 @@ plugins:
       scripts:
         - gen_pages.py
 
+validation:
+  links:
+    anchors: ignore
+
 markdown_extensions:
   - admonition
   - attr_list


### PR DESCRIPTION
- deploy-k3s: stop enabling TF_LOG by default; avoid redis-cli auth warning\n- docs-site: map .github -> github in generated site; fall back to GitHub blob for non-doc links\n- mkdocs: suppress anchor-validation noise (keep missing-file warnings)\n- update READMEs for readme-coverage