### PR TITLE
feat(vault): update default policy to allow OIDC role read and auth_url generation

### DIFF
--- a/2.platform/91.vault-policy-default.tf
+++ b/2.platform/91.vault-policy-default.tf
@@ -1,8 +1,8 @@
 # Update the built-in 'default' policy to allow OIDC UI access
 # The default policy is attached to all tokens, including unauthenticated ones.
 # 
-# Issue: Vault UI needs to read OIDC role config (redirect_uris) before login to construct the auth URL.
-# Without this, "Sign in with OIDC" fails with "permission denied" when fetching role.
+# Issue: Vault needs to allow unauthenticated access to OIDC config endpoints 
+# for the login flow to work (e.g. fetching auth_url, checking requirements).
 
 resource "vault_policy" "default" {
   name = "default"
@@ -38,19 +38,24 @@ resource "vault_policy" "default" {
         capabilities = ["list", "read"]
     }
 
-    # Allow reading OIDC auth config (Required for Vault UI OIDC Login)
-    # This allows the UI to read redirect_uris and other public config from the role.
+    # Allow unauthenticated access to OIDC auth URL generation
+    # Fixes: "permission denied" on "PUT .../oidc/auth_url"
+    path "auth/oidc/oidc/auth_url" {
+        capabilities = ["read", "update"]
+    }
+
+    # Allow reading OIDC role config (for UI to know redirect URIs)
     path "auth/oidc/role/*" {
         capabilities = ["read"]
     }
 
-    # Required for Vault UI to list mounts
-    path "sys/internal/ui/mounts/*" {
+    # Allow listing available auth methods (for UI)
+    path "sys/auth" {
         capabilities = ["read"]
     }
-
-    # Allow listing available auth methods
-    path "sys/auth" {
+    
+    # Required for Vault UI to list mounts
+    path "sys/internal/ui/mounts/*" {
         capabilities = ["read"]
     }
   EOT


### PR DESCRIPTION
## Problem
Vault UI and CLI cannot initiate OIDC login because unauthenticated users lack permissions to:
1. Fetch auth URL (`auth/oidc/oidc/auth_url`) -> `permission denied`
2. Read OIDC role config (`auth/oidc/role/*`) -> UI cannot construct redirect URI

## Solution
Update the built-in `default` policy via Terraform to explicitly allow read/update on these OIDC paths.

## Logic
- The `default` policy is attached to all tokens, including the ephemeral token used during login.
- Granting these permissions allows the OIDC handshake to proceed.
- It does NOT grant access to secrets.

## Verification
- `vault login -method=oidc role=reader` should succeed.
- Vault UI OIDC login should succeed.