### PR TITLE
fix: use pod name pattern for Atlantis StatefulSet verification

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -233,19 +233,21 @@ jobs:
           echo ""
           echo "=== L1: Atlantis readiness ==="
           # Note: Atlantis is deployed in "bootstrap" namespace (see 1.bootstrap/2.atlantis.tf)
-          ATLANTIS_SELECTOR=""
-          if kubectl -n bootstrap get pods -l app.kubernetes.io/instance=atlantis --no-headers 2>/dev/null | grep -q .; then
-            ATLANTIS_SELECTOR="app.kubernetes.io/instance=atlantis"
-          elif kubectl -n bootstrap get pods -l app.kubernetes.io/name=atlantis --no-headers 2>/dev/null | grep -q .; then
-            ATLANTIS_SELECTOR="app.kubernetes.io/name=atlantis"
-          else
+          # Atlantis uses StatefulSet, so we check by pod name pattern
+          if ! kubectl -n bootstrap get pods -o name | grep -q "^pod/atlantis-"; then
             echo "::error::Atlantis pods not found in namespace bootstrap"
             kubectl -n bootstrap get pods -o wide || true
             exit 1
           fi
 
-          kubectl -n bootstrap wait --for=condition=Ready pod -l "${ATLANTIS_SELECTOR}" --timeout=180s
-          kubectl -n bootstrap get pods -l "${ATLANTIS_SELECTOR}" -o wide
+          # Wait for Atlantis pod to be ready (StatefulSet pod name: atlantis-0)
+          kubectl -n bootstrap wait --for=condition=Ready pod/atlantis-0 --timeout=180s || {
+            echo "::error::Atlantis pod failed to become ready"
+            kubectl -n bootstrap get pods -o wide
+            kubectl -n bootstrap describe pod/atlantis-0 || true
+            exit 1
+          }
+          kubectl -n bootstrap get pods -l app.kubernetes.io/name=atlantis -o wide || kubectl -n bootstrap get pods -o wide | grep atlantis
 
       # =========================================================
       # 2. Platform Layer (L2): Vault, Observability, Ingress


### PR DESCRIPTION
## 问题

合并 PR #258 后，CI 仍然失败，错误信息：
```
Atlantis pods not found in namespace bootstrap
```

但实际 pod 存在：`atlantis-0   1/1     Running`

## 根本原因

Atlantis 使用 StatefulSet 部署，pod 名称是 `atlantis-0`，但标签选择器 `app.kubernetes.io/instance=atlantis` 和 `app.kubernetes.io/name=atlantis` 没有匹配到 pod。

## 修复方案

1. ✅ 改用 pod 名称模式匹配（`atlantis-*`）来检查 pod 是否存在
2. ✅ 直接等待 `pod/atlantis-0` 就绪，而不是使用标签选择器
3. ✅ 添加更详细的错误输出（包括 pod describe）用于调试

## 验证

- [x] 代码 lint 检查通过
- [ ] 等待 CI 验证修复是否生效

## 相关 PR

修复了 PR #258 合并后仍然存在的验证问题。