### PR TITLE
fix: correct L4 file check logic and add CI review

### DIFF
--- a/.github/workflows/CI_REVIEW.md
+++ b/.github/workflows/CI_REVIEW.md
@@ -1,0 +1,165 @@
+# CI Workflow 审查报告
+
+## 审查范围
+- `.github/workflows/deploy-k3s.yml` - 主要部署 workflow
+- `.github/actions/terraform-setup/action.yml` - Terraform 设置 action
+
+## 已发现的问题
+
+### 🔴 关键问题（会导致 CI 失败）
+
+#### 1. **Atlantis Pod 选择器问题** ✅ 已修复（PR #259）
+- **位置**: Line 237-250
+- **问题**: 使用标签选择器查找 StatefulSet pod，但标签可能不匹配
+- **状态**: PR #259 已修复，改用 pod 名称模式匹配
+- **风险**: 高 - 会导致 L1 验证失败
+
+#### 2. **xargs -r 兼容性问题** ⚠️ 潜在问题
+- **位置**: Line 189
+- **问题**: `xargs -r` 在 macOS/BSD 上不支持（`-r` 是 GNU 扩展）
+- **影响**: 在 macOS runner 上可能失败
+- **建议**: 使用 `xargs -r` 前检查或使用 `|| true`（已使用）
+
+#### 3. **L4 验证中的文件检查逻辑错误** 🔴 严重
+- **位置**: Line 626
+- **问题**: `[ ! -f "4.apps/*.tf" ]` 会把通配符当作字面字符串，永远不会匹配
+- **影响**: L4 验证可能错误跳过或执行
+- **当前代码**: 
+  ```bash
+  if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
+  ```
+- **修复**: 应该只使用 `ls` 检查，或使用 `shopt -s nullglob`
+
+#### 4. **Vault Pre-flight 检查的竞态条件** ⚠️ 中等
+- **位置**: Line 285-336
+- **问题**: L2 apply 前检查 Vault 外部 URL，但 L1 刚部署完，Vault 可能还没完全就绪
+- **影响**: 如果 Vault 启动慢，pre-flight 可能失败
+- **缓解**: 已有 10s connect-timeout，但可能需要重试逻辑
+
+#### 5. **Kubeconfig 获取失败处理** ⚠️ 中等
+- **位置**: `.github/actions/terraform-setup/action.yml:300-310`
+- **问题**: kubeconfig 获取失败时只输出 warning，但后续步骤需要 KUBECONFIG
+- **影响**: 如果集群未部署，后续 kubectl 命令会全部失败
+- **建议**: 在首次部署时应该更优雅地处理
+
+### 🟡 中等风险问题
+
+#### 6. **L3 验证中的 wait_ready 使用 `|| true`** ⚠️
+- **位置**: Line 439-442
+- **问题**: 所有 `wait_ready` 调用都加了 `|| true`，失败不会导致 CI 失败
+- **影响**: 数据库未就绪时 CI 仍会通过（假绿）
+- **建议**: 移除 `|| true` 或改为非阻塞但记录警告
+
+#### 7. **Port-forward 清理可能不完整** ⚠️
+- **位置**: Line 491-519, 532-562
+- **问题**: 使用 trap 清理 port-forward，但如果脚本提前退出可能不执行
+- **影响**: 可能留下僵尸进程
+- **缓解**: 已有 trap，但可以考虑更健壮的清理
+
+#### 8. **Terraform workspace 创建竞态** ⚠️
+- **位置**: Line 342, 408, 612
+- **问题**: `terraform workspace select X || terraform workspace new X` 在并发时可能失败
+- **影响**: 如果多个 CI 同时运行可能冲突
+- **缓解**: 通常不会并发，但应该考虑
+
+#### 9. **Vault token 检查依赖外部网络** ⚠️
+- **位置**: Line 316-334
+- **问题**: 依赖外部域名解析和 HTTPS 连接
+- **影响**: 网络问题会导致 CI 失败
+- **缓解**: 已有超时和错误处理
+
+#### 10. **Cert-manager rollout 超时** ⚠️
+- **位置**: Line 229-231
+- **问题**: 180s 超时可能不够，特别是首次部署
+- **影响**: cert-manager 启动慢时可能超时
+- **建议**: 考虑增加超时或添加重试
+
+### 🟢 低风险问题
+
+#### 11. **错误处理中的 `|| true` 过多**
+- **位置**: 多处
+- **问题**: 某些关键错误被 `|| true` 掩盖
+- **影响**: 可能隐藏真实问题
+- **建议**: 区分关键和非关键错误
+
+#### 12. **L4 验证中的硬编码命名空间**
+- **位置**: Line 632-634
+- **问题**: 硬编码 `prod` 环境
+- **影响**: 如果未来需要支持 staging，需要修改
+- **建议**: 使用变量
+
+#### 13. **Secret 验证不完整**
+- **位置**: Line 56-97
+- **问题**: 只验证必需 secrets，可选 secrets 缺失时可能静默失败
+- **影响**: 某些功能可能不可用但 CI 通过
+- **建议**: 添加可选 secrets 的警告
+
+## 修复优先级
+
+### P0 (立即修复)
+1. ✅ Atlantis pod 选择器（PR #259）
+2. 🔴 L4 文件检查逻辑错误（Line 626）
+
+### P1 (高优先级)
+3. ⚠️ L3 wait_ready 的 `|| true` 问题
+4. ⚠️ Vault pre-flight 竞态条件
+
+### P2 (中优先级)
+5. ⚠️ Cert-manager 超时
+6. ⚠️ Terraform workspace 竞态
+
+### P3 (低优先级)
+7. 🟢 其他优化项
+
+## 建议的修复
+
+### 修复 1: L4 文件检查逻辑
+```bash
+# 当前（错误）:
+if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
+
+# 修复:
+if ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
+```
+
+### 修复 2: L3 wait_ready 移除 `|| true`
+```bash
+# 当前:
+wait_ready "app.kubernetes.io/name=postgresql" "PostgreSQL" || true
+
+# 修复（如果需要非阻塞，至少记录错误）:
+wait_ready "app.kubernetes.io/name=postgresql" "PostgreSQL" || {
+  echo "::warning::PostgreSQL not ready, but continuing..."
+  FAILED=1
+}
+```
+
+### 修复 3: Vault pre-flight 添加重试
+```bash
+# 添加重试逻辑
+for i in {1..3}; do
+  HEALTH_RESPONSE=$(curl -sf --connect-timeout 10 "${VAULT_URL}/v1/sys/health" 2>&1 || echo "FAIL")
+  if [ "$HEALTH_RESPONSE" != "FAIL" ]; then
+    break
+  fi
+  echo "Retry $i/3..."
+  sleep 5
+done
+```
+
+## 测试建议
+
+1. **测试 L4 文件检查**: 创建/删除 `4.apps/*.tf` 文件，验证逻辑
+2. **测试 Atlantis pod 选择器**: 验证 PR #259 修复后是否工作
+3. **测试 Vault pre-flight**: 模拟 Vault 启动慢的场景
+4. **测试并发 workspace**: 模拟多个 CI 同时运行
+
+## 总结
+
+主要问题：
+- ✅ Atlantis pod 选择器已修复（PR #259）
+- 🔴 L4 文件检查逻辑需要立即修复
+- ⚠️ 多个中等风险问题需要关注
+
+建议先修复 L4 文件检查逻辑，然后逐步优化其他问题。
+

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -623,7 +623,8 @@ jobs:
           set -euo pipefail
 
           # Skip if L4 was skipped (no .tf files)
-          if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
+          # Note: [ ! -f "4.apps/*.tf" ] doesn't work with globs, use ls instead
+          if ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
             echo "⏭️ Skipping L4 Verify: No apps deployed"
             exit 0
           fi


### PR DESCRIPTION
## 问题

L4 验证步骤中的文件检查逻辑有错误：

```bash
if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
```

`[ ! -f "4.apps/*.tf" ]` 会把通配符当作字面字符串，永远不会匹配到文件，导致逻辑错误。

## 修复

- ✅ 移除无效的 `[ ! -f ]` 检查
- ✅ 只使用 `ls` 来检查文件是否存在
- ✅ 添加注释说明原因

## 额外内容

- 📋 添加完整的 CI 审查报告（`.github/workflows/CI_REVIEW.md`）
  - 识别了 13 个潜在问题点
  - 按优先级分类（P0-P3）
  - 提供修复建议和代码示例

## 相关

这是 CI 专家审查的一部分，旨在提高 CI 的可靠性和可维护性。