### PR TITLE
fix: correct L4 file check and ArangoDB health check

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -499,12 +499,11 @@ jobs:
             echo "::error::ArangoDB: Pod not found"
             FAILED=1
           else
-            # Use kubectl exec to check ArangoDB API directly inside the pod
-            code="$(kubectl exec -n "${NS}" "${ARANGO_POD}" -- curl -sf -o /dev/null -w "%{http_code}" --max-time 5 http://127.0.0.1:8529/_api/version 2>/dev/null || echo "000")"
-            if [ "${code}" = "200" ] || [ "${code}" = "401" ] || [ "${code}" = "403" ]; then
-              echo "✅ ArangoDB: Reachable (HTTP ${code})"
+            # ArangoDB image doesn't have curl, use arangosh to check server
+            if kubectl exec -n "${NS}" "${ARANGO_POD}" -- arangosh --server.endpoint tcp://127.0.0.1:8529 --server.authentication false --javascript.execute-string "db._version()" >/dev/null 2>&1; then
+              echo "✅ ArangoDB: Reachable"
             else
-              echo "::error::ArangoDB: Unreachable (HTTP ${code})"
+              echo "::error::ArangoDB: Unreachable"
               FAILED=1
             fi
           fi
@@ -570,7 +569,8 @@ jobs:
           set -euo pipefail
 
           # Skip if L4 was skipped (no .tf files)
-          if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
+          # Note: [ -f "*.tf" ] doesn't work with globs, use ls instead
+          if ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
             echo "⏭️ Skipping L4 Verify: No apps deployed"
             exit 0
           fi


### PR DESCRIPTION
## Problems Fixed

### 1. ArangoDB Health Check (from PR #260)
- **Issue**: `kubectl exec -- curl` returns HTTP 000 because ArangoDB image doesn't have `curl`
- **Fix**: Use `arangosh` which is available in the ArangoDB container

### 2. L4 File Check Logic (from closed PR #261)
- **Issue**: `[ ! -f "4.apps/*.tf" ]` treats glob as literal string, never matches
- **Fix**: Only use `ls 4.apps/*.tf` to check for files

## Changes
```diff
# ArangoDB: curl → arangosh
-code="$(kubectl exec ... -- curl -sf ... http://127.0.0.1:8529/_api/version)"
+kubectl exec ... -- arangosh --server.endpoint tcp://127.0.0.1:8529 --javascript.execute-string "db._version()"

# L4: remove invalid [ -f ] check
-if [ ! -f "4.apps/*.tf" ] 2>/dev/null && ! ls 4.apps/*.tf ...
+if ! ls 4.apps/*.tf 1>/dev/null 2>&1; then
```