### PR TITLE
fix(ci): use ephemeral curl pod for arangodb check

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -499,10 +499,13 @@ jobs:
             echo "::error::ArangoDB: Pod not found"
             FAILED=1
           else
-            # Check if ArangoDB HTTP server responds (/_api/version doesn't require auth)
-            ARANGO_VERSION="$(kubectl exec -n "${NS}" "${ARANGO_POD}" -- wget -qO- --no-check-certificate --timeout=5 https://127.0.0.1:8529/_api/version 2>/dev/null || true)"
-            if echo "${ARANGO_VERSION}" | grep -q "version"; then
-              echo "✅ ArangoDB: Reachable ($(echo "${ARANGO_VERSION}" | grep -o '"version":"[^"]*"' | head -1))"
+            # Check if ArangoDB HTTP server responds (using ephemeral curl pod as in-pod wget is limited)
+            ARANGO_IP="$(kubectl get pod -n "${NS}" "${ARANGO_POD}" -o jsonpath='{.status.podIP}')"
+            if kubectl run "arango-check-${GITHUB_RUN_ID}-${RANDOM}" \
+              --image=curlimages/curl:8.5.0 \
+              --restart=Never --rm -i \
+              -- curl -k -s -f --connect-timeout 5 "https://${ARANGO_IP}:8529/_api/version"; then
+              echo "✅ ArangoDB: Reachable"
             else
               echo "::error::ArangoDB: Unreachable"
               FAILED=1


### PR DESCRIPTION
## Problem\nArangoDB container has a minimal `wget` that fails SSL verification with self-signed certs (no `--no-check-certificate` support).\n\n## Solution\nUse `kubectl run` to launch an ephemeral `curlimages/curl` pod to check health from within the cluster.\n\n## Action Required\nAfter CI passes, run `atlantis apply -p platform` to sync the Vault OIDC role.