### PR TITLE
refactor: arangodb health check via restapi provider

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -494,23 +494,7 @@ jobs:
           fi
 
           echo "Checking ArangoDB..."
-          ARANGO_POD="$(kubectl get pods -n "${NS}" -l arango_deployment=arangodb -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
-          if [ -z "${ARANGO_POD}" ]; then
-            echo "::error::ArangoDB: Pod not found"
-            FAILED=1
-          else
-            # Check if ArangoDB HTTP server responds (using ephemeral curl pod as in-pod wget is limited)
-            ARANGO_IP="$(kubectl get pod -n "${NS}" "${ARANGO_POD}" -o jsonpath='{.status.podIP}')"
-            if kubectl run "arango-check-${GITHUB_RUN_ID}-${RANDOM}" \
-              --image=curlimages/curl:8.5.0 \
-              --restart=Never --rm -i \
-              -- curl -k -s -f --connect-timeout 5 "https://${ARANGO_IP}:8529/_api/version"; then
-              echo "✅ ArangoDB: Reachable"
-            else
-              echo "::error::ArangoDB: Unreachable"
-              FAILED=1
-            fi
-          fi
+          echo "✅ Application Layer Connectivity Checks Complete (ArangoDB verified via Terraform)"
 
           echo ""
           echo "=== Summary ==="

--- a/3.data/.terraform.lock.hcl
+++ b/3.data/.terraform.lock.hcl
@@ -1,22 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/external" {
-  version = "2.3.5"
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "~> 2.0"
   hashes = [
-    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
-    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
-    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
-    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
-    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
-    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
-    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
-    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
-    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
-    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
-    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+    "h1:poWSAAtK4FI1x79C2OyLaNrvWUGTQdr1ZT58edDz+Rs=",
+    "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",
+    "zh:1773f08a412d1a5f89bac174fe1efdfd255ecdda92d31a2e31937e4abf843a2f",
+    "zh:1da2db1f940c5d34e31c2384c7bd7acba68725cc1d3ba6db0fec42efe80dbfb7",
+    "zh:20dc810fb09031bcfea4f276e1311e8286d8d55705f55433598418b7bcc76357",
+    "zh:326a01c86ba90f6c6eb121bacaabb85cfa9059d6587aea935a9bbb6d3d8e3f3f",
+    "zh:5a3737ea1e08421fe3e700dc833c6fd2c7b8c3f32f5444e844b3fe0c2352757b",
+    "zh:5f490acbd0348faefea273cb358db24e684cbdcac07c71002ee26b6cfd2c54a0",
+    "zh:777688cda955213ba637e2ac6b1994e438a5af4d127a34ecb9bb010a8254f8a8",
+    "zh:7acc32371053592f55ee0bcbbc2f696a8466415dea7f4bc5a6573f03953fc926",
+    "zh:81f0108e2efe5ae71e651a8826b61d0ce6918811ccfdc0e5b81b2cfb0f7f57fe",
+    "zh:88b785ea7185720cf40679cb8fa17e57b8b07fd6322cf2d4000b835282033d81",
+    "zh:89d833336b5cd027e671b46f9c5bc7d10c5109e95297639bbec8001da89aa2f7",
+    "zh:df108339a89d4372e5b13f77bd9d53c02a04362fb5d85e1d9b6b47292e30821c",
+    "zh:e8a2e3a5c50ca124e6014c361d72a9940d8e815f37ae2d1e9487ac77c3043013",
   ]
 }
 
@@ -83,6 +86,26 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.9"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/vault" {
   version     = "4.8.0"
   constraints = "~> 4.0"
@@ -102,5 +125,28 @@ provider "registry.terraform.io/hashicorp/vault" {
     "zh:de1fb712784dd8415f011ca5346a34f87fab6046c730557615247e511dbc7d98",
     "zh:e3eafae7da550f86cae395d6660b2a0e93ec8d2b0e0e5ef982ec762e961fc952",
     "zh:ff35fb1ab6add288f0f368981e56f780b50405accd1937131cba1137999c8d83",
+  ]
+}
+
+provider "registry.terraform.io/mastercard/restapi" {
+  version     = "1.20.0"
+  constraints = "~> 1.19"
+  hashes = [
+    "h1:NDgmXCDpGksOYqP+iStlyA384/WMIvyU+QOYn65g798=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:59fa61b12b201d1e9aa20d81f4b9280c901f7b921fa6eaa5d4dffb7bf61cbf1c",
+    "zh:67817734d9eb2bb24e543fd45e71369ca5d363a4b0710bdf28936968cd79fe80",
+    "zh:7edaad673f0bbe667f69ac32a66c6b1c7b97a0e15d65eda89292df44df0eab14",
+    "zh:7f37e523049115e54dc6372e8606ddd94ca7a447b263bdac88815593c3c8bbba",
+    "zh:8a5bd02154951ab11e5ef5a3353ebc167c46d2b62fbb9a61b205d4286545b78c",
+    "zh:8a8b49cfd7af06124d85a14bd90940c37e9d9021448f9db74d661e0a43ac1d54",
+    "zh:a4f1ce26bd6c2435d6fed2cecfc2878fd81e971602c7c93c6cce1c2489dbfb7b",
+    "zh:acc93df983428fb65c5ba3f99e21651cfad6acdf14c13298e020aebe38502023",
+    "zh:adeb6b57ef263dda3ca004c012046ca7aaaa8e6bc4fa624a166e627cab55113f",
+    "zh:b6477a739c8971da305605272a3f9968f22cc8e0427c58ed341253cc9946c6b5",
+    "zh:b83dd1fc0f8af7f99eb7c079cfc92db55904c9ea6899073dca9c119da54fd2f8",
+    "zh:dc0a268b0c6a0780e06c4247d4dfc1fa64c958ef9bcc1ead57d397074358d017",
+    "zh:dc27c532c662db1599c6a64a0382b582c6a8a56cc081fcca8e76eff0816974b5",
+    "zh:eab8f76e61c26c39f4b7313587c882dfd2816894f31b449a5a0c1848ae751035",
   ]
 }

--- a/3.data/4.arangodb.tf
+++ b/3.data/4.arangodb.tf
@@ -162,6 +162,31 @@ resource "kubectl_manifest" "arangodb_deployment" {
 }
 
 # =============================================================================
+# ArangoDB API Health Check
+# =============================================================================
+
+# This resource performs a GET request to /_api/version to ensure the database
+# is responsive and ready after deployment.
+resource "restapi_object" "arangodb_health" {
+  path      = "/_api/version"
+  object_id = "health" # Arbitrary ID as we are only reading
+
+  # Only read/verify, do not attempt to create or delete
+  read_method    = "GET"
+  create_method  = "GET" # Placeholder
+  update_method  = "GET" # Placeholder
+  destroy_method = "GET" # Placeholder
+
+  data = jsonencode({})
+
+  debug = true
+
+  depends_on = [
+    kubectl_manifest.arangodb_deployment
+  ]
+}
+
+# =============================================================================
 # Outputs
 # =============================================================================
 

--- a/3.data/providers.tf
+++ b/3.data/providers.tf
@@ -32,3 +32,17 @@ provider "vault" {
   # Skip TLS verification for internal communication
   skip_tls_verify = true
 }
+
+# RestAPI provider for ArangoDB health checks and operations
+# URI uses internal K8s DNS
+provider "restapi" {
+  uri = "https://arangodb.${local.namespace_name}.svc.cluster.local:8529"
+
+  username = "root"
+  password = data.vault_kv_secret_v2.arangodb.data["password"]
+
+  insecure              = true # Internal self-signed cert
+  write_returns_object  = false
+  create_returns_object = false
+  debug                 = true
+}

--- a/3.data/versions.tf
+++ b/3.data/versions.tf
@@ -26,5 +26,9 @@ terraform {
       source  = "hashicorp/time"
       version = "~> 0.9"
     }
+    restapi = {
+      source  = "mastercard/restapi"
+      version = "~> 1.19"
+    }
   }
 }


### PR DESCRIPTION
## Changes\n- Migrated ArangoDB health check from CI shell scripts to Terraform `restapi` provider.\n- Updated `3.data` layer with `mastercard/restapi` provider config.\n- Cleaned up `.github/workflows/deploy-k3s.yml`.\n\n## Benefits\n- Better state management and drift detection.\n- Uniformity with Casdoor application management.\n- Eliminates dependency on container-internal tools like `wget`/`curl`.