### PR TITLE
fix(casdoor): add ?id=admin/{id} to update_path for REST API compatibility

### DIFF
--- a/2.platform/90.casdoor-apps.tf
+++ b/2.platform/90.casdoor-apps.tf
@@ -20,7 +20,7 @@ resource "restapi_object" "provider_github" {
 
   path        = "/add-provider"
   create_path = "/add-provider"
-  update_path = "/update-provider"
+  update_path = "/update-provider?id=admin/{id}"
   # Whitebox: Explicitly use {id} to force ID into the query parameter.
   # Expected: /api/get-provider?id=admin/GitHub
   read_path    = "/get-provider?id=admin/{id}"
@@ -88,7 +88,7 @@ resource "restapi_object" "app_portal_gate" {
 
   path         = "/add-application"
   create_path  = "/add-application"
-  update_path  = "/update-application"
+  update_path  = "/update-application?id=admin/{id}"
   read_path    = "/get-application?id=admin/{id}"
   destroy_path = "/delete-application?id=admin/{id}"
   id_attribute = "name"
@@ -110,7 +110,7 @@ resource "restapi_object" "app_vault_oidc" {
 
   path         = "/add-application"
   create_path  = "/add-application"
-  update_path  = "/update-application"
+  update_path  = "/update-application?id=admin/{id}"
   read_path    = "/get-application?id=admin/{id}"
   destroy_path = "/delete-application?id=admin/{id}"
   id_attribute = "name"
@@ -132,7 +132,7 @@ resource "restapi_object" "app_dashboard_oidc" {
 
   path         = "/add-application"
   create_path  = "/add-application"
-  update_path  = "/update-application"
+  update_path  = "/update-application?id=admin/{id}"
   read_path    = "/get-application?id=admin/{id}"
   destroy_path = "/delete-application?id=admin/{id}"
   id_attribute = "name"
@@ -154,7 +154,7 @@ resource "restapi_object" "app_kubero_oidc" {
 
   path         = "/add-application"
   create_path  = "/add-application"
-  update_path  = "/update-application"
+  update_path  = "/update-application?id=admin/{id}"
   read_path    = "/get-application?id=admin/{id}"
   destroy_path = "/delete-application?id=admin/{id}"
   id_attribute = "name"


### PR DESCRIPTION
## Problem

L2 Apply failed with 404 error from Casdoor REST API:
```
Error: unexpected response code '404'
with restapi_object.provider_github[0]
```

Terraform detected drift in `update_path` from `/update-provider?id=admin/{id}` to `/update-provider` and tried to update, but Casdoor API requires the ID in query params.

## Fix

Added `?id=admin/{id}` to all `update_path` attributes in `90.casdoor-apps.tf`:
- `restapi_object.provider_github`
- `restapi_object.app_portal_gate`
- `restapi_object.app_vault_oidc`
- `restapi_object.app_dashboard_oidc`
- `restapi_object.app_kubero_oidc`