### PR TITLE
fix(casdoor): add update_method=POST to restapi_object resources

### DIFF
--- a/2.platform/90.casdoor-apps.tf
+++ b/2.platform/90.casdoor-apps.tf
@@ -18,9 +18,10 @@
 resource "restapi_object" "provider_github" {
   count = local.casdoor_enabled ? 1 : 0
 
-  path        = "/add-provider"
-  create_path = "/add-provider"
-  update_path = "/update-provider?id=admin/{id}"
+  path          = "/add-provider"
+  create_path   = "/add-provider"
+  update_path   = "/update-provider?id=admin/{id}"
+  update_method = "POST"
   # Whitebox: Explicitly use {id} to force ID into the query parameter.
   # Expected: /api/get-provider?id=admin/GitHub
   read_path    = "/get-provider?id=admin/{id}"
@@ -86,12 +87,13 @@ locals {
 resource "restapi_object" "app_portal_gate" {
   count = local.portal_gate_enabled ? 1 : 0
 
-  path         = "/add-application"
-  create_path  = "/add-application"
-  update_path  = "/update-application?id=admin/{id}"
-  read_path    = "/get-application?id=admin/{id}"
-  destroy_path = "/delete-application?id=admin/{id}"
-  id_attribute = "name"
+  path          = "/add-application"
+  create_path   = "/add-application"
+  update_path   = "/update-application?id=admin/{id}"
+  update_method = "POST"
+  read_path     = "/get-application?id=admin/{id}"
+  destroy_path  = "/delete-application?id=admin/{id}"
+  id_attribute  = "name"
 
   data = jsonencode(merge(local.common_app_config, {
     name         = "portal-gate"
@@ -108,12 +110,13 @@ resource "restapi_object" "app_portal_gate" {
 resource "restapi_object" "app_vault_oidc" {
   count = local.portal_gate_enabled ? 1 : 0
 
-  path         = "/add-application"
-  create_path  = "/add-application"
-  update_path  = "/update-application?id=admin/{id}"
-  read_path    = "/get-application?id=admin/{id}"
-  destroy_path = "/delete-application?id=admin/{id}"
-  id_attribute = "name"
+  path          = "/add-application"
+  create_path   = "/add-application"
+  update_path   = "/update-application?id=admin/{id}"
+  update_method = "POST"
+  read_path     = "/get-application?id=admin/{id}"
+  destroy_path  = "/delete-application?id=admin/{id}"
+  id_attribute  = "name"
 
   data = jsonencode(merge(local.common_app_config, {
     name         = "vault-oidc"
@@ -130,12 +133,13 @@ resource "restapi_object" "app_vault_oidc" {
 resource "restapi_object" "app_dashboard_oidc" {
   count = local.portal_gate_enabled ? 1 : 0
 
-  path         = "/add-application"
-  create_path  = "/add-application"
-  update_path  = "/update-application?id=admin/{id}"
-  read_path    = "/get-application?id=admin/{id}"
-  destroy_path = "/delete-application?id=admin/{id}"
-  id_attribute = "name"
+  path          = "/add-application"
+  create_path   = "/add-application"
+  update_path   = "/update-application?id=admin/{id}"
+  update_method = "POST"
+  read_path     = "/get-application?id=admin/{id}"
+  destroy_path  = "/delete-application?id=admin/{id}"
+  id_attribute  = "name"
 
   data = jsonencode(merge(local.common_app_config, {
     name         = "dashboard-oidc"
@@ -152,12 +156,13 @@ resource "restapi_object" "app_dashboard_oidc" {
 resource "restapi_object" "app_kubero_oidc" {
   count = local.portal_gate_enabled ? 1 : 0
 
-  path         = "/add-application"
-  create_path  = "/add-application"
-  update_path  = "/update-application?id=admin/{id}"
-  read_path    = "/get-application?id=admin/{id}"
-  destroy_path = "/delete-application?id=admin/{id}"
-  id_attribute = "name"
+  path          = "/add-application"
+  create_path   = "/add-application"
+  update_path   = "/update-application?id=admin/{id}"
+  update_method = "POST"
+  read_path     = "/get-application?id=admin/{id}"
+  destroy_path  = "/delete-application?id=admin/{id}"
+  id_attribute  = "name"
 
   data = jsonencode(merge(local.common_app_config, {
     name         = "kubero-oidc"


### PR DESCRIPTION
Terraform state had update_method=POST but code didn't specify it, causing drift to null and 404 API errors. Explicitly set POST for all Casdoor REST API update operations.