### PR TITLE
fix(ci): correct vault kv get CLI syntax for KV v2

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -164,10 +164,11 @@ jobs:
           
           echo "=== Checking Static Credentials ==="
           for secret in postgres redis clickhouse arangodb; do
-            if kubectl exec -n platform "$VAULT_POD" -- vault kv get "secret/data/${secret}" >/dev/null 2>&1; then
-              echo "✅ secret/data/${secret}: available"
+            # vault kv get CLI auto-adds /data/ prefix for KV v2
+            if kubectl exec -n platform "$VAULT_POD" -- vault kv get "secret/${secret}" >/dev/null 2>&1; then
+              echo "✅ secret/${secret}: available"
             else
-              echo "::error::secret/data/${secret}: NOT FOUND"
+              echo "::error::secret/${secret}: NOT FOUND"
               exit 1
             fi
           done


### PR DESCRIPTION
vault kv get CLI auto-adds /data/ prefix for KV v2 engines.

Using `vault kv get secret/data/xxx` actually accesses `secret/data/data/xxx`.
Fixed to use `vault kv get secret/xxx` which correctly accesses `secret/data/xxx`.

This is the final piece of the Vault KV v2 path fix chain:
1. PR #293 - Fixed Terraform vault_kv_secret_v2 name fields
2. PR #294 - Fixed restapi update_path  
3. PR #295 - Fixed restapi update_method
4. **This PR** - Fixed CI vault kv get command syntax