### PR TITLE
fix(ci): pass VAULT_TOKEN to kubectl exec for vault CLI auth

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -165,7 +165,8 @@ jobs:
           echo "=== Checking Static Credentials ==="
           for secret in postgres redis clickhouse arangodb; do
             # vault kv get CLI auto-adds /data/ prefix for KV v2
-            if kubectl exec -n platform "$VAULT_POD" -- vault kv get "secret/${secret}" >/dev/null 2>&1; then
+            # Pass VAULT_TOKEN env to authenticate inside vault pod
+            if kubectl exec -n platform "$VAULT_POD" -- env VAULT_TOKEN="${VAULT_TOKEN}" vault kv get "secret/${secret}" >/dev/null 2>&1; then
               echo "✅ secret/${secret}: available"
             else
               echo "::error::secret/${secret}: NOT FOUND"
@@ -174,7 +175,7 @@ jobs:
           done
           
           echo "=== Checking Dynamic Credentials (optional) ==="
-          if kubectl exec -n platform "$VAULT_POD" -- vault read database/creds/app-readonly 2>/dev/null; then
+          if kubectl exec -n platform "$VAULT_POD" -- env VAULT_TOKEN="${VAULT_TOKEN}" vault read database/creds/app-readonly 2>/dev/null; then
             echo "✅ Dynamic credentials: configured"
           else
             echo "⚠️ Dynamic credentials: not configured (enable_postgres_backend=false)"


### PR DESCRIPTION
Root cause: kubectl exec into vault pod runs vault CLI without authentication. Terraform API works because provider has token, but kubectl exec doesn't.

## Fix
Pass VAULT_TOKEN env var to both static and dynamic credential verification steps:
```bash
kubectl exec -n platform "$VAULT_POD" -- env VAULT_TOKEN="${VAULT_TOKEN}" vault kv get "secret/${secret}"
```

This is the final fix in the Vault KV verification chain:
1. PR #293 - Terraform name fields
2. PR #294 - restapi update_path  
3. PR #295 - restapi update_method
4. PR #296 - vault kv get CLI syntax
5. **This PR** - VAULT_TOKEN authentication