### PR TITLE
fix: use required_version instead of defaultTFVersion for TF 1.11

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.6
+          terraform_version: 1.11.0
           terraform_wrapper: false
 
       - name: Format Check

--- a/1.bootstrap/2.atlantis.tf
+++ b/1.bootstrap/2.atlantis.tf
@@ -31,8 +31,6 @@ resource "helm_release" "atlantis" {
         orgAllowlist = "github.com/${var.github_org}/*"
         atlantisUrl  = "https://${local.domains.atlantis}"
 
-        # Terraform version - 1.11+ required for WriteOnly attributes (e.g. clickhousedbops)
-        defaultTFVersion = "1.11.0"
         # Environment for R2 Backend (AWS_* used by S3 backend)
         # AND TF_VAR_* for Terraform variables
         environment = {

--- a/1.bootstrap/providers.tf
+++ b/1.bootstrap/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     aws = {

--- a/2.platform/versions.tf
+++ b/2.platform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     cloudflare = {

--- a/3.data/versions.tf
+++ b/3.data/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     kubernetes = {

--- a/4.apps/versions.tf
+++ b/4.apps/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     kubernetes = {


### PR DESCRIPTION
## Summary

Fixes the Atlantis deploy timeout caused by PR #312.

## Changes

1. **Revert** `defaultTFVersion = "1.11.0"` from Atlantis Helm config
2. **Add** `required_version = ">= 1.11.0"` to all layers (L1-L4)

## Why

- `required_version` in HCL has **higher precedence** than `defaultTFVersion`
- Atlantis will download TF 1.11+ based on the constraint
- No need to modify Atlantis Helm release (avoids pod restart issues)

## Related

- Reverts the problematic part of PR #312
- Unblocks PR #310 (SigNoz with clickhousedbops)