### PR TITLE
fix(L1): use chart version instead of revision in validate trigger

### DIFF
--- a/1.bootstrap/3.dns_and_cert.tf
+++ b/1.bootstrap/3.dns_and_cert.tf
@@ -275,7 +275,8 @@ resource "null_resource" "validate_cert" {
 # Validate Atlantis health (nodep module check)
 resource "null_resource" "validate_atlantis" {
   triggers = {
-    atlantis_release = helm_release.atlantis.metadata[0].revision
+    # Use chart version instead of revision (revision changes during apply, causing TF error)
+    atlantis_version = helm_release.atlantis.version
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Summary

Fixes deploy-k3s CI failure after Atlantis upgrade.

## Problem

```
Error: Provider produced inconsistent final plan
null_resource.validate_atlantis triggers["atlantis_release"]: was "138", but now "139"
```

The helm `revision` changes during `terraform apply` (when helm upgrade runs), causing TF to report inconsistent plan.

## Solution

Changed trigger from `helm_release.atlantis.metadata[0].revision` to `helm_release.atlantis.version`.

Version is stable during apply and achieves the same goal (re-validate when atlantis changes).

## Note

Atlantis 5.23.0 was actually deployed successfully, this fix is just for the validation step.