### PR TITLE
refactor: move L1 bootstrap checks to provider resources

### DIFF
--- a/1.bootstrap/.terraform.lock.hcl
+++ b/1.bootstrap/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:AymCb0DCWzmyLqn1qEhVs2pcFUZGT/kxPK+I/BObFH8=",
+    "h1:LzkjMzVRQqwvbY+tF3b+Wxj9BDLZ6Qj9rpPKVppodDU=",
+    "zh:0e601ae36ebc32eb8c10aff4c48c1125e471fa09f5668465af7581c9057fa22c",
+    "zh:1773f08a412d1a5f89bac174fe1efdfd255ecdda92d31a2e31937e4abf843a2f",
+    "zh:1da2db1f940c5d34e31c2384c7bd7acba68725cc1d3ba6db0fec42efe80dbfb7",
+    "zh:20dc810fb09031bcfea4f276e1311e8286d8d55705f55433598418b7bcc76357",
+    "zh:326a01c86ba90f6c6eb121bacaabb85cfa9059d6587aea935a9bbb6d3d8e3f3f",
+    "zh:5a3737ea1e08421fe3e700dc833c6fd2c7b8c3f32f5444e844b3fe0c2352757b",
+    "zh:5f490acbd0348faefea273cb358db24e684cbdcac07c71002ee26b6cfd2c54a0",
+    "zh:777688cda955213ba637e2ac6b1994e438a5af4d127a34ecb9bb010a8254f8a8",
+    "zh:7acc32371053592f55ee0bcbbc2f696a8466415dea7f4bc5a6573f03953fc926",
+    "zh:81f0108e2efe5ae71e651a8826b61d0ce6918811ccfdc0e5b81b2cfb0f7f57fe",
+    "zh:88b785ea7185720cf40679cb8fa17e57b8b07fd6322cf2d4000b835282033d81",
+    "zh:89d833336b5cd027e671b46f9c5bc7d10c5109e95297639bbec8001da89aa2f7",
+    "zh:df108339a89d4372e5b13f77bd9d53c02a04362fb5d85e1d9b6b47292e30821c",
+    "zh:e8a2e3a5c50ca124e6014c361d72a9940d8e815f37ae2d1e9487ac77c3043013",
+  ]
+}
+
 provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "4.52.5"
   constraints = "~> 4.0"
@@ -49,6 +72,27 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/dns" {
+  version     = "3.4.3"
+  constraints = "~> 3.4"
+  hashes = [
+    "h1:8wz2nUJwdMb9YWFX67SbX5HoFLINXm+XRQxWxVy0I1I=",
+    "h1:P2UFh9AR5GCZpLgQdAHO3WLqyJbuKKYXTkPZq/D3xwU=",
+    "zh:11526db629adb59e5069aa9af6549f9a274e00365db5e2ea32ed3fef548b2112",
+    "zh:198a1cd01c6bcb2c00146ac38aabcf04e9f027442bbe9c3ec7aa31220a6964d9",
+    "zh:3b6d141ef3ad2978b6efddc780b3444e50e4c3988ccd45f8756398669ec52189",
+    "zh:561adc509f35999e42b2b519eb84e937dd2a3b30138c401834ea9a2adc7418a6",
+    "zh:61960b0e2d5bcdba1fbe3863f636e06727d7330a9f63a92f42bdb511f1943119",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ee3a93fe3e45ad16285f2d0ca3a6b6afc4906784b2da1af89a3a0818f3b303b",
+    "zh:7fc8329861864ee69fffa29b17cafbe67eecbcef3c30749e31659d7837ac8983",
+    "zh:b29c35262e7fc6619ac80fa38d13076975b613e6a884044bd163599413596e35",
+    "zh:b778b9c4dfba7ae2ac1658bb4b0d1c45a5edd80893e1f8bbee4b080145a11909",
+    "zh:f41a325947b78f4d9b51a68a0c6167bc37302356ec47bc8e513106f4f58db732",
+    "zh:fd7110602e3fc39f70e2b757ffae675fc8232dd3d8534892a0b91e4d5c7539ff",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
   constraints = "~> 2.0"
@@ -67,6 +111,27 @@ provider "registry.terraform.io/hashicorp/helm" {
     "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
     "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.5.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:8bUoPwS4hahOvzCBj6b04ObLVFXCEmEN8T/5eOHmWOM=",
+    "h1:KsglDyFg9a9CIlOKxSSl8gDi+SAKfY+uvIZO1+SpeAc=",
+    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
+    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
+    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
+    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
+    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
+    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
+    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
+    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
+    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
+    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
   ]
 }
 
@@ -130,5 +195,26 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
     "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
     "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "h1:eSX+RgYfeumojmeJ9Y5CbnkH2NkBC+9vUEolqdQVtGw=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
   ]
 }

--- a/1.bootstrap/4.traefik_config.tf
+++ b/1.bootstrap/4.traefik_config.tf
@@ -1,37 +1,11 @@
-# Deploy Traefik HelmChartConfig to k3s auto-deploy directory
-# This enables 'allowCrossNamespace' for Traefik middleware
+# Deploy Traefik HelmChartConfig via kubectl_manifest to avoid SSH file copy.
+resource "kubectl_manifest" "traefik_config" {
+  yaml_body = local.traefik_config_yaml
 
-resource "null_resource" "traefik_config" {
-  triggers = {
-    host           = var.vps_host
-    config_content = sha256(local.traefik_config_yaml)
-  }
-
-  connection {
-    type        = "ssh"
-    host        = var.vps_host
-    user        = var.vps_user
-    port        = var.ssh_port
-    private_key = var.ssh_private_key
-    agent       = false
-    timeout     = "5m"
-  }
-
-  provisioner "file" {
-    content     = local.traefik_config_yaml
-    destination = "/tmp/traefik-config.yaml"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "sudo mkdir -p /var/lib/rancher/k3s/server/manifests",
-      "sudo mv /tmp/traefik-config.yaml /var/lib/rancher/k3s/server/manifests/traefik-config.yaml",
-      # Wait a bit for k3s to pick it up? Not strictly necessary as it's eventually consistent
-    ]
-  }
+  server_side_apply = true
 
   depends_on = [
-    null_resource.k3s_server
+    null_resource.kubeconfig
   ]
 }
 

--- a/1.bootstrap/README.md
+++ b/1.bootstrap/README.md
@@ -19,7 +19,7 @@ Managed by **GitHub Actions only** (not Atlantis).
 | `1.k3s.tf` | K3s Cluster | SSH-based VPS bootstrap |
 | `2.atlantis.tf` | Atlantis | GitOps CI/CD for L2-L4 |
 | `3.dns_and_cert.tf` | DNS + Certs | Cloudflare + cert-manager |
-| `5.platform_pg.tf` | Platform PostgreSQL | Trust anchor DB for Vault/Casdoor (uses `initdb.scripts` for automatic database creation) |
+| `5.platform_pg.tf` | Platform PostgreSQL | Trust anchor DB for Vault/Casdoor (init Job via `kubectl_manifest`) |
 
 ## Key Files
 

--- a/1.bootstrap/locals.tf
+++ b/1.bootstrap/locals.tf
@@ -57,9 +57,6 @@ locals {
     "*.${local.internal_domain}"
   ]))
 
-  # YAML list for Certificate dnsNames - use with indent() in heredoc
-  base_cert_domains_yaml     = yamlencode(local.base_cert_domains)
-  internal_cert_domains_yaml = yamlencode(local.internal_cert_domains)
 }
 
 data "cloudflare_zones" "internal" {
@@ -69,4 +66,3 @@ data "cloudflare_zones" "internal" {
     status = "active"
   }
 }
-

--- a/1.bootstrap/providers.tf
+++ b/1.bootstrap/providers.tf
@@ -14,6 +14,22 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.4"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.5"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
 
     local = {
       source  = "hashicorp/local"
@@ -51,4 +67,7 @@ provider "kubernetes" {
   config_path = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
 }
 
-
+provider "kubectl" {
+  config_path      = fileexists(local.kubeconfig_path) ? local.kubeconfig_path : null
+  load_config_file = fileexists(local.kubeconfig_path)
+}

--- a/docs/change_log/2025-12-22.l1_provider_migration.md
+++ b/docs/change_log/2025-12-22.l1_provider_migration.md
@@ -1,0 +1,56 @@
+# 2025-12-22: L1 Bootstrap Provider Migration
+
+## Summary
+Migrate L1 bootstrap validation and configuration from `null_resource` + provisioners to native Terraform providers (kubectl, dns, http, time).
+
+## Changes
+
+### Replaced Resources
+
+1. **DNS & Cert validation** (`1.bootstrap/3.dns_and_cert.tf`)
+   - `null_resource.validate_dns` → `data.dns_a_record_set` + `time_sleep` + postcondition
+   - `null_resource.validate_cert` → removed (covered by health check)
+   - `null_resource.validate_atlantis` → `data.http` with retry + postcondition
+   - `null_resource.cluster_issuer_letsencrypt_prod` → `kubectl_manifest`
+   - `null_resource.wildcard_certificate_public/internal` → `kubectl_manifest`
+
+2. **Storage provisioner restart** (`1.bootstrap/4.storage.tf`)
+   - `null_resource.restart_local_path_provisioner` → `kubernetes_manifest` with annotation-based trigger
+
+3. **Traefik config deployment** (`1.bootstrap/4.traefik_config.tf`)
+   - `null_resource.traefik_config` (SSH file copy) → `kubectl_manifest` (server-side apply)
+
+4. **PostgreSQL initialization** (`1.bootstrap/5.platform_pg.tf`)
+   - `null_resource.vault_pg_schema` → `kubectl_manifest` Job resource
+   - `null_resource.casdoor_database` → merged into single init Job
+
+### New Providers
+
+- `alekc/kubectl` (~> 2.0): CRD resources without plan-time validation
+- `hashicorp/dns` (~> 3.4): DNS resolution validation
+- `hashicorp/http` (~> 3.5): HTTPS health checks with retry
+- `hashicorp/time` (~> 0.13): Cooldown/wait for DNS/cert propagation
+
+## Benefits
+
+1. **Plan-time validation**: Failures detected during `terraform plan` instead of `apply`
+2. **No SSH dependency**: Traefik config deployed via Kubernetes API
+3. **Better idempotency**: Provider-managed resources vs. shell scripts
+4. **Improved error handling**: Postconditions provide clear failure messages
+
+## Breaking Changes
+
+- **Atlantis health check now fails apply** if `/healthz` is unreachable after retry window
+  - Previously: Warning only, apply succeeds
+  - Now: Hard failure with postcondition error
+  - Impact: First-time deployments may need retry if Atlantis starts slowly
+
+## Testing
+
+- CI validated format, lint, and validate for all layers
+- Lock file updated for darwin_amd64 + linux_amd64
+
+## Related
+
+- PR: https://github.com/wangzitian0/infra/pull/321
+- Commit: ded4855

--- a/docs/change_log/README.md
+++ b/docs/change_log/README.md
@@ -3,6 +3,7 @@
 Time-ordered history of completed work. Each entry is an immutable snapshot (named `YYYY-MM-DD.*.md`). `0.check_now.md` points to the active context; when a sprint/topic closes, its notes move here as a dated log.
 
 ## Recent Entries
+- [2025-12-22: L1 Bootstrap Provider Migration](./2025-12-22.l1_provider_migration.md)
 - [2025-12-22: Fix Data Layer CI and Clarify SSOT Responsibilities](./2025-12-22.fix_data_ci_and_docs.md)
 - [2025-12-22: Implement Vault RBAC with Identity Groups](./2025-12-22.vault_rbac_identity_groups.md)
 - [2025-12-19: Vault OIDC Permission Fix & Native Drift Defense](./2025-12-19.vault_oidc_drift_defense.md)


### PR DESCRIPTION
## Summary
- migrate cert-manager issuer/certs and Traefik config to `kubectl_manifest`
- replace local-path restart and Postgres init with provider-managed resources
- add dns/http/time providers and update L1 lock + README
- shift Atlantis DNS/health checks to data sources with cooldown + retry

## Notes
- Atlantis health check now fails the apply if `/healthz` is unreachable after the wait/retry window.

## Testing
- `terraform -chdir=1.bootstrap providers lock -platform=darwin_amd64 -platform=linux_amd64`
