### PR TITLE
fix(ci): enable port-forward for clickhouse provider in CI

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -137,9 +137,23 @@ jobs:
       - name: Apply Infrastructure (L3 - Data)
         if: github.event_name == 'push'
         working-directory: 3.data
+        env:
+          KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
         run: |
+          # Start port-forward for ClickHouse provider (needed for connectivity from runner)
+          echo "Starting ClickHouse port-forward..."
+          kubectl -n data-prod port-forward svc/clickhouse 8123:8123 > /dev/null 2>&1 &
+          PID=$!
+          
+          # Wait for port-forward to be ready
+          sleep 5
+          
           terraform workspace select prod || terraform workspace new prod
-          terraform apply -auto-approve
+          
+          # Trap to ensure cleanup even on failure
+          trap "kill $PID" EXIT
+          
+          terraform apply -auto-approve -var="clickhouse_host=127.0.0.1"
 
       - name: Verify Data Services Health (L3)
         if: github.event_name == 'push'

--- a/3.data/providers.tf
+++ b/3.data/providers.tf
@@ -37,7 +37,7 @@ provider "vault" {
 # Used for managing users, databases, and privileges in ClickHouse
 # Connects to ClickHouse HTTP interface using admin credentials from Vault
 provider "clickhousedbops" {
-  host     = "clickhouse.${local.namespace_name}.svc.cluster.local"
+  host     = var.clickhouse_host != "" ? var.clickhouse_host : "clickhouse.${local.namespace_name}.svc.cluster.local"
   port     = 8123
   protocol = "http"
 

--- a/3.data/variables.tf
+++ b/3.data/variables.tf
@@ -24,6 +24,12 @@ variable "vault_root_token" {
   }
 }
 
+variable "clickhouse_host" {
+  description = "ClickHouse host address. Defaults to in-cluster DNS; override to localhost for port-forward."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # R2 Backend Variables (for terraform_remote_state to read L2 outputs)
 # Passed by Atlantis via TF_VAR_* from L1


### PR DESCRIPTION
## Summary
Fixes connectivity issue where `clickhousedbops` provider could not reach the internal Kubernetes service from GitHub Actions runner.

## Changes
- **Terraform**: Added `clickhouse_host` variable to `3.data` to allow overriding the connection host (defaults to internal DNS).
- **CI**: Added `kubectl port-forward` to the `deploy-k3s.yml` workflow to bridge the runner to the internal ClickHouse service.