### PR TITLE
fix(L1): use kubectl_manifest for local-path-provisioner patch

### DIFF
--- a/1.bootstrap/4.storage.tf
+++ b/1.bootstrap/4.storage.tf
@@ -80,8 +80,9 @@ resource "kubernetes_storage_class" "local_path_retain" {
 }
 
 # Restart local-path-provisioner when any config field changes
-resource "kubernetes_manifest" "local_path_provisioner_restart" {
-  manifest = {
+# Use kubectl_manifest with server_side_apply to patch existing Deployment
+resource "kubectl_manifest" "local_path_provisioner_restart" {
+  yaml_body = yamlencode({
     apiVersion = "apps/v1"
     kind       = "Deployment"
     metadata = {
@@ -97,7 +98,9 @@ resource "kubernetes_manifest" "local_path_provisioner_restart" {
         }
       }
     }
-  }
+  })
+
+  server_side_apply = true
 
   depends_on = [kubernetes_config_map_v1.local_path_config]
 }


### PR DESCRIPTION
## Problem

After merging #321, L1 apply failed with:
```
Error: Cannot create resource that already exists
with kubernetes_manifest.local_path_provisioner_restart,
on 4.storage.tf line 83
resource "kube-system/local-path-provisioner" already exists
```

**Root cause**: `kubernetes_manifest` tries to CREATE the Deployment, but `local-path-provisioner` already exists (created by k3s).

## Solution

Change from `kubernetes_manifest` to `kubectl_manifest` with `server_side_apply = true`:
- Allows patching existing resources instead of creating them
- Consistent with other `kubectl_manifest` usage in `3.dns_and_cert.tf`

## Changes

- `1.bootstrap/4.storage.tf`: Replace `kubernetes_manifest` with `kubectl_manifest`
- Add `server_side_apply = true` to enable patch mode
- Add comment explaining the approach

## Testing

- [ ] CI validates terraform fmt/lint
- [ ] L1 apply succeeds without conflicts

## References

- Failed run: https://github.com/wangzitian0/infra/actions/runs/20414742691
- Original PR: #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)