### PR TITLE
fix(ci): add KUBECONFIG env to L4 Apps apply step

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -232,6 +232,8 @@ jobs:
       - name: Apply Infrastructure (L4 - Apps)
         if: github.event_name == 'push'
         working-directory: 4.apps
+        env:
+          KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
         run: |
           if ls *.tf 1> /dev/null 2>&1; then
             terraform workspace select default || terraform workspace new default


### PR DESCRIPTION
L4 Apps apply was failing because KUBECONFIG environment variable was not set, causing 'Kubernetes cluster unreachable' error.