### PR TITLE
fix(l4): add helm provider with kubeconfig for CI

### DIFF
--- a/4.apps/providers.tf
+++ b/4.apps/providers.tf
@@ -3,6 +3,13 @@ provider "kubernetes" {
   # When config_path is null, provider uses in-cluster config automatically
 }
 
+# Helm provider for SigNoz and other Helm charts
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path != "" ? var.kubeconfig_path : null
+  }
+}
+
 # Vault provider for reading secrets
 provider "vault" {
   address         = var.vault_address


### PR DESCRIPTION
The helm provider was missing kubeconfig configuration, causing 'Kubernetes cluster unreachable' error in CI.