### PR TITLE
fix(l4): add helm provider to required_providers

### DIFF
--- a/4.apps/2.signoz.tf
+++ b/4.apps/2.signoz.tf
@@ -47,7 +47,7 @@ resource "helm_release" "signoz" {
   chart      = "signoz"
   version    = "0.52.0" # Pin version for reproducibility
 
-  wait          = false  # Don't wait - SigNoz has complex startup dependencies
+  wait          = false # Don't wait - SigNoz has complex startup dependencies
   wait_for_jobs = false
   timeout       = 600 # 10 minutes
 
@@ -73,7 +73,7 @@ resource "helm_release" "signoz" {
         enabled = true
         image = {
           registry   = "docker.io"
-          repository = "bitnamilegacy/zookeeper"  # bitnami moved to bitnamilegacy
+          repository = "bitnamilegacy/zookeeper" # bitnami moved to bitnamilegacy
           tag        = "3.9.3-debian-12-r22"
         }
         resources = {

--- a/4.apps/versions.tf
+++ b/4.apps/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "alekc/kubectl"
       version = "~> 2.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"


### PR DESCRIPTION
## Summary
- Add `helm` provider declaration to `4.apps/versions.tf` to fix "Unsupported block type: kubernetes" error
- The helm provider was missing from required_providers, causing terraform to not recognize the `kubernetes` block syntax in the helm provider configuration

## Root Cause
PR #331 added helm provider configuration to `providers.tf` but didn't add the provider declaration to `versions.tf`. Without the declaration, Terraform doesn't know where to get the helm provider from.

## Test plan
- [x] Verify terraform fmt passes
- [ ] CI passes at L4 Apps apply step

🤖 Generated with [Claude Code](https://claude.com/claude-code)