### PR TITLE
fix(ci): correct atlantis command from 'atl' to 'atlantis'

### DIFF
--- a/.github/workflows/atlantis-comment-format.yml
+++ b/.github/workflows/atlantis-comment-format.yml
@@ -96,7 +96,7 @@ jobs:
             // Build next step guidance
             let nextStep;
             if (isPlan && isSuccess) {
-              nextStep = `\`\`\`\natl apply -p ${project}\n\`\`\``;
+              nextStep = `\`\`\`\natlantis apply -p ${project}\n\`\`\``;
             } else if (isPlan && !isSuccess) {
               nextStep = 'Fix errors below, then run `atlantis plan`';
             } else if (isApply && isSuccess) {


### PR DESCRIPTION
## Problem

The Atlantis comment formatter was showing incorrect command syntax:
```
atl apply -p platform  ❌ Wrong
```

This caused user confusion as copying the command would fail.

## Solution

Changed to correct syntax:
```
atlantis apply -p platform  ✅ Correct
```

## Root Cause Analysis

From reviewing ~100 recent Atlantis comments, identified UX issues:

| Issue | Severity | Status |
|-------|----------|--------|
| Wrong command format (`atl` vs `atlantis`) | Critical | Fixed in this PR |
| Project shows as 'unknown' on init failures | Medium | Future improvement |
| Error details hidden in collapsed section | Low | Consider for future |

## Testing

After merge, new Plan comments will show correct `atlantis apply` command.