### PR TITLE
fix(ci): remove obsolete DB port-forwards from L2 deploy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -99,17 +99,13 @@ Fix errors below, then run `atlantis plan`  (失败时)
 
 ## Database Port-Forwards in CI
 
-`deploy-k3s.yml` uses `kubectl port-forward` to connect to databases for L2/L3 terraform providers:
+`deploy-k3s.yml` uses `kubectl port-forward` to connect to databases for L3 terraform providers:
 
-### ClickHouse Provider
-- **L2 (Platform)**: Port-forwards to `data-staging` namespace
+### ClickHouse Provider (L3 only)
 - **L3 (Data)**: Port-forwards to `data-prod` namespace
 - Override variable: `-var="clickhouse_host=127.0.0.1"`
 
-### PostgreSQL Provider
-- **L2 (Platform)**: Port-forwards to `data-staging` namespace
-- Override variable: `-var="postgres_host=127.0.0.1"`
-- Used for creating application-specific database users (e.g., OpenPanel)
+> **Note**: L2 (Platform) no longer requires database port-forwards after PR #340 removed temporary DB providers.
 
 ---
 *Last updated: 2025-12-22*

--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -116,41 +116,8 @@ jobs:
         env:
           KUBECONFIG: ${{ env.KUBECONFIG_PATH }}
         run: |
-          # Start port-forward for ClickHouse provider (L2 uses data-staging)
-          echo "Starting ClickHouse port-forward for L2..."
-          kubectl -n data-staging port-forward svc/clickhouse 8123:8123 > /dev/null 2>&1 &
-          CH_PID=$!
-
-          # Wait for port-forward to be ready
-          echo "Waiting for port 8123..."
-          for i in {1..30}; do
-            if curl -s http://127.0.0.1:8123/ping >/dev/null 2>&1; then
-              echo "✅ ClickHouse port-forward ready"
-              break
-            fi
-            sleep 1
-          done
-
-          # Start port-forward for PostgreSQL provider (L2 uses data-staging)
-          echo "Starting PostgreSQL port-forward for L2..."
-          kubectl -n data-staging port-forward svc/postgresql 5432:5432 > /dev/null 2>&1 &
-          PG_PID=$!
-
-          # Wait for port-forward to be ready
-          echo "Waiting for port 5432..."
-          for i in {1..30}; do
-            if nc -z 127.0.0.1 5432 2>/dev/null; then
-              echo "✅ PostgreSQL port-forward ready"
-              break
-            fi
-            sleep 1
-          done
-
           terraform workspace select default || terraform workspace new default
-
-          trap "kill $CH_PID $PG_PID 2>/dev/null || true" EXIT
-
-          terraform apply -auto-approve -var="clickhouse_host=127.0.0.1" -var="postgres_host=127.0.0.1"
+          terraform apply -auto-approve
 
       - name: Verify L2 (Vault Status)
         env:


### PR DESCRIPTION
## Summary
- PR #340 removed temporary DB providers from L2 (ClickHouse, PostgreSQL)
- But `deploy-k3s.yml` still passed `-var="clickhouse_host"` and `-var="postgres_host"` to L2 apply
- This caused `Value for undeclared variable` errors: https://github.com/wangzitian0/infra/actions/runs/20428405402/job/58693492470

## Changes
- Remove port-forward setup for ClickHouse/PostgreSQL in L2 (lines 119-151)
- Simplify L2 apply to just `terraform apply -auto-approve`
- Update README to reflect L3-only port-forward requirement

## Test Plan
- [ ] CI passes after merge
- [ ] L2 apply succeeds without port-forwards
- [ ] L3 still works with clickhouse_host variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)