### PR TITLE
fix: enforce L3 environment isolation for namespaces

### DIFF
--- a/envs/3.data-shared/1.postgres.tf
+++ b/envs/3.data-shared/1.postgres.tf
@@ -15,16 +15,12 @@
 # Namespace (per-environment: data-staging, data-prod)
 # =============================================================================
 
-locals {
-  namespace_name = "data-${terraform.workspace}"
-}
-
 resource "kubernetes_namespace" "data" {
   metadata {
     name = local.namespace_name
     labels = {
       layer = "L3"
-      env   = terraform.workspace
+      env   = local.env_name
     }
   }
 }

--- a/envs/3.data-shared/variables.tf
+++ b/envs/3.data-shared/variables.tf
@@ -39,7 +39,20 @@ variable "r2_bucket" {
   type        = string
 }
 
+locals {
+  # Use environment from Terragrunt if available, otherwise fallback to workspace
+  # This ensures data-staging, data-prod instead of conflicting data-default
+  env_name       = var.environment != "" ? var.environment : terraform.workspace
+  namespace_name = "data-${local.env_name}"
+}
+
 variable "r2_account_id" {
   description = "Cloudflare R2 account ID"
   type        = string
+}
+
+variable "environment" {
+  description = "Execution environment (staging, prod). Passed by Terragrunt."
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Fixes the 'data-default already exists' conflict by using environment-specific namespaces (data-staging, data-prod).