### PR TITLE
fix(portal): add auth DNS record and reorganize Portal layout

### DIFF
--- a/1.bootstrap/3.dns_and_cert.tf
+++ b/1.bootstrap/3.dns_and_cert.tf
@@ -11,6 +11,7 @@ locals {
     openpanel  = true  # HTTPS via proxy
     home       = true  # Homer Portal - HTTPS via proxy
     sso        = false # SSO (Casdoor) - DNS only (avoid Cloudflare caching/WAF issues)
+    auth       = true  # OAuth2-Proxy callback for Portal SSO Gate
     k3s        = false # API on 6443, must stay DNS-only
   }
 

--- a/1.bootstrap/README.md
+++ b/1.bootstrap/README.md
@@ -83,6 +83,11 @@ L1 Atlantis passes the following variables to L2/L3:
 
 ## Recent Changes
 
+### 2025-12-23: Portal SSO Gate DNS Fix
+- **DNS**: Added `auth.internal.domain` for OAuth2-Proxy callback endpoint
+- **Purpose**: Required for Portal SSO Gate to function (redirect URI)
+- **Location**: Proxied DNS record (HTTPS via Cloudflare)
+
 ### 2025-12-23: Homer Portal DNS Record
 - **DNS**: Added `home.internal.domain` subdomain for Homer Portal dashboard
 - **Purpose**: Unified landing page with quick links to all infrastructure services

--- a/2.platform/4.portal.tf
+++ b/2.platform/4.portal.tf
@@ -66,27 +66,27 @@ locals {
             tag      = "iac"
             url      = "https://atlantis.${local.internal_domain}"
             target   = "_blank"
+          },
+          {
+            name     = "Casdoor Admin"
+            logo     = "https://cdn.casbin.org/img/casbin.svg"
+            subtitle = "User & role management"
+            tag      = "admin"
+            url      = "https://sso.${local.internal_domain}"
+            target   = "_blank"
           }
         ]
       },
       {
-        name = "Platform (Emergency)"
+        name = "Emergency Access"
         icon = "fas fa-exclamation-triangle"
         items = [
           {
             name     = "Vault (Root Token)"
             logo     = "https://www.datocms-assets.com/2885/1620155117-brandhcvaultprimaryattributedcolor.svg"
-            subtitle = "⚠️ Break-glass access only"
+            subtitle = "⚠️ Break-glass when OIDC fails"
             tag      = "emergency"
             url      = "https://secrets.${local.internal_domain}/ui/vault/auth?with=token"
-            target   = "_blank"
-          },
-          {
-            name     = "Casdoor Admin"
-            logo     = "https://cdn.casbin.org/img/casbin.svg"
-            subtitle = "⚙️ User & role management"
-            tag      = "admin"
-            url      = "https://sso.${local.internal_domain}"
             target   = "_blank"
           }
         ]

--- a/2.platform/README.md
+++ b/2.platform/README.md
@@ -29,7 +29,7 @@ Depends on L1 (bootstrap) for K8s cluster availability.
 | `7.vault-secrets-operator.tf` | VSO | Vault Secrets Operator for automatic Vault → K8s Secret sync (Issue #351) |
 | `90.provider_restapi.tf` | RestAPI Provider | Casdoor REST API provider (M2M credentials via casdoor-builtin-app) |
 | `90.casdoor-apps.tf` | Casdoor Apps | OIDC applications & Providers (GitHub) via `restapi_object` resources |
-| `4.portal.tf` | Homer Portal | SSO-protected unified dashboard with categorized service links. Emergency access (Root Token, Admin) separated in "Platform (Emergency)" section. |
+| `4.portal.tf` | Homer Portal | SSO-protected unified dashboard with categorized service links. Emergency section contains only Vault Root Token for break-glass access. |
 | `91.casdoor-roles.tf` | Casdoor Roles | Defines `vault-admin`, `vault-developer`, `vault-viewer` roles in Casdoor. Uses `TF_VAR_gh_account` to auto-assign admin user. |
 | `91.vault-auth.tf` | Vault OIDC Auth | Vault OIDC backend connected to Casdoor |
 | `91.vault-auth-kubernetes.tf` | Vault K8s Auth | Kubernetes authentication backend for pod identity + VSO role |
@@ -69,8 +69,8 @@ terragrunt apply
 
 - **Portal**: `https://home.<internal_domain>` (e.g., `home.zitian.party`) - **⭐ Start here!**
   - 🔒 **Protected by SSO**: Login with GitHub to access
-  - Unified landing page with categorized service links
-  - Emergency access options (Vault Root Token, Casdoor Admin) in separate "Platform (Emergency)" section
+  - Unified landing page with categorized service links (Platform Services includes Casdoor Admin)
+  - Emergency section: Vault Root Token only (break-glass when OIDC fails)
 - **Vault**: `https://secrets.<internal_domain>` (e.g., `secrets.zitian.party`) - HTTPS via cert-manager; manual init/unseal required
 - **Dashboard**: `https://kdashboard.<internal_domain>` (e.g., `kdashboard.zitian.party`) - HTTPS via cert-manager
 - **Casdoor**: `https://sso.<internal_domain>` (e.g., `sso.zitian.party`) - Unified SSO
@@ -162,7 +162,7 @@ To deploy Portal SSO Gate for non-OIDC portals (e.g., Dashboard):
    - https://kdashboard.zitian.party (Dashboard)
 
 ---
-*Last updated: 2025-12-23 (Added Vault Secrets Operator for automatic Vault → K8s Secret sync - Issue #351)*
+*Last updated: 2025-12-23 (Portal reorganization: Casdoor Admin moved to Platform Services, Emergency section simplified to Vault Root Token only)*
 
 ---
 


### PR DESCRIPTION
## Summary
- Add missing `auth.zitian.party` DNS record for OAuth2-Proxy callback (fixes Portal SSO Gate not working)
- Move Casdoor Admin from Emergency to Platform Services section
- Simplify Emergency section to only contain Vault Root Token (true break-glass access)

## Root Cause
The Portal SSO Gate (`enable_portal_sso_gate=true`) was not functioning because the `auth.zitian.party` DNS record was missing from `1.bootstrap/3.dns_and_cert.tf`. OAuth2-Proxy uses `https://auth.zitian.party/oauth2/callback` as its redirect URI.

## Changes
| File | Change |
|------|--------|
| `1.bootstrap/3.dns_and_cert.tf` | Add `auth = true` to DNS records |
| `1.bootstrap/README.md` | Document auth DNS addition |
| `2.platform/4.portal.tf` | Reorganize Portal layout |
| `2.platform/README.md` | Update component descriptions |

## Test plan
- [ ] Atlantis plan succeeds for both L1 and L2
- [ ] After L1 apply: verify `auth.zitian.party` resolves
- [ ] After L2 apply: verify `home.zitian.party` requires SSO login
- [ ] Verify Portal shows correct layout (Casdoor Admin in Platform Services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)