### PR TITLE
fix(ci): post-merge PR detection and remove duplicate 👀

### DIFF
--- a/.github/workflows/infra-flash-update.yml
+++ b/.github/workflows/infra-flash-update.yml
@@ -83,26 +83,12 @@ jobs:
               per_page: 100
             });
 
-            // Find trigger comment and add 👀 reaction
+            // Find trigger comment for history link (👀 is handled by atlantis-acknowledge.yml)
             const atlantisCommentTime = new Date(context.payload.comment.created_at);
             const triggerComment = comments
               .filter(c => new Date(c.created_at) < atlantisCommentTime)
               .filter(c => (c.body || '').toLowerCase().includes(`atlantis ${stage.toLowerCase()}`))
               .pop();
-
-            if (triggerComment) {
-              try {
-                await github.rest.reactions.createForIssueComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: triggerComment.id,
-                  content: 'eyes'
-                });
-                console.log(`Added 👀 to trigger comment #${triggerComment.id}`);
-              } catch (e) {
-                console.log(`Could not add reaction: ${e.message}`);
-              }
-            }
 
             const prUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
             const MARKER = `<!-- infra-flash-commit:${targetSha} -->`;

--- a/.github/workflows/post-merge-verify.yml
+++ b/.github/workflows/post-merge-verify.yml
@@ -50,6 +50,24 @@ jobs:
               return;
             }
 
+            // Method 1: Parse PR number from commit message (squash-and-merge format: "... (#123)")
+            const commit = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha
+            });
+            const message = commit.data.commit.message;
+            const prMatch = message.match(/\(#(\d+)\)/);
+
+            if (prMatch) {
+              const prNumber = prMatch[1];
+              console.log(`Found PR #${prNumber} from commit message`);
+              core.setOutput('pr_number', prNumber);
+              core.setOutput('has_pr', 'true');
+              return;
+            }
+
+            // Method 2: Fallback to API lookup (for merge commits)
             const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,7 +76,7 @@ jobs:
 
             const merged = prs.data.find(pr => pr.merged_at);
             if (merged) {
-              console.log(`Found merged PR #${merged.number}`);
+              console.log(`Found merged PR #${merged.number} via API`);
               core.setOutput('pr_number', merged.number.toString());
               core.setOutput('has_pr', 'true');
             } else {

--- a/docs/ssot/ops.pipeline.md
+++ b/docs/ssot/ops.pipeline.md
@@ -175,7 +175,7 @@ flowchart TD
 
 ---
 
-## 5. 运维节点与触发矩阵
+## 5. 运维指令矩阵
 
 我们将流程分为 **自动 (Push)** 和 **指令 (Comment)** 两个平面。
 
@@ -204,7 +204,7 @@ flowchart TD
 
 ---
 
-## 5. Dashboard Schema
+## 6. Dashboard Schema
 
 每个 `infra-flash` 评论遵循紧凑结构（~12行可见）：
 
@@ -265,7 +265,7 @@ flowchart TD
 
 ---
 
-## 6. SLA 与超时预期
+## 7. SLA 与超时预期
 
 | 阶段 | 正常耗时 | 超时阈值 | 超时处理 |
 |:---|:---|:---|:---|
@@ -278,7 +278,7 @@ flowchart TD
 
 ---
 
-## 7. 并发与竞态处理
+## 8. 并发与竞态处理
 
 ### 快速连续 Push
 - **策略**: 使用 `concurrency` 取消旧的 CI run。
@@ -294,7 +294,7 @@ flowchart TD
 
 ---
 
-## 8. 回滚策略
+## 9. 回滚策略
 
 ### Apply 失败场景
 
@@ -322,7 +322,7 @@ flowchart TD
 
 ---
 
-## 9. Troubleshooting 决策树
+## 10. Troubleshooting 决策树
 
 ```mermaid
 flowchart TD
@@ -365,7 +365,7 @@ flowchart TD
 
 ---
 
-## 10. 守卫节点与准入标准 (Guards & Admission)
+## 11. 守卫节点与准入标准 (Guards & Admission)
 
 为了确保流水线的健壮性，执行过程中嵌入了多个“守卫”节点。
 
@@ -378,7 +378,7 @@ flowchart TD
 
 ---
 
-## 11. 关键工作流清单 (Workflows)
+## 12. 关键工作流清单 (Workflows)
 
 | 文件 | 身份 | 职责 | 触发器 |
 |:---|:---|:---|:---|
@@ -393,7 +393,7 @@ flowchart TD
 
 ---
 
-## 12. 验收准则与测试场景 (UAT)
+## 13. 验收准则与测试场景 (UAT)
 
 | 场景 | 操作 | 预期 Dashboard 行为 | 预期 Identity |
 |:---|:---|:---|:---|
@@ -408,7 +408,7 @@ flowchart TD
 ---
 
 
-## 13. 版本要求与 SSOT
+## 14. 版本要求与 SSOT
 
 ### Terraform 版本 SSOT
 
@@ -435,7 +435,7 @@ Terraform 版本通过 **`.terraform-version`** 文件统一管理，确保四�
 
 ---
 
-## 14. 实现状态与 TODO
+## 15. 实现状态与 TODO
 
 ### 当前实现状态 (2025-12)
 


### PR DESCRIPTION
## Summary

Fixes issues found after PR #354 merge:

1. **Post-merge verification skipped** - Squash-merge creates new commit SHA not linked to PR via API. Now parses PR# from commit message first.

2. **Double 👀 on comments** - Both `atlantis-acknowledge.yml` and `infra-flash-update.yml` were adding 👀. Removed from `infra-flash-update.yml`.

3. **ops.pipeline.md numbering** - Had duplicate section 5. Fixed to 1-15 sequential.

## Changes

| File | Fix |
|:---|:---|
| `post-merge-verify.yml` | Parse PR# from commit message `(#123)` pattern |
| `infra-flash-update.yml` | Remove duplicate 👀 reaction code |
| `ops.pipeline.md` | Fix section numbering 1-15 |

## Test Plan

- [ ] Merge this PR
- [ ] Verify post-merge-verify finds PR# from commit message
- [ ] Verify only single 👀 on atlantis commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)