### PR TITLE
fix(ci): use infra-flash App Token for post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,19 @@ jobs:
       cancel-in-progress: false  # CRITICAL: Never cancel apply
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ATLANTIS_GH_APP_ID }}
+          private-key: ${{ secrets.ATLANTIS_GH_APP_KEY }}
+      
       - name: Setup Terraform
         uses: ./.github/actions/terraform-setup
         with:
           secrets_json: ${{ toJSON(secrets) }}
+          
       - name: Digger Apply
         id: digger
         uses: diggerhq/digger@v0.6.80
@@ -73,12 +82,13 @@ jobs:
           terragrunt-version: 0.68.4
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       
       - name: Find Merged PR
         id: find-pr
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Find PR associated with this merge commit
             const commits = await github.rest.repos.listPullRequestsAssociatedWithCommit({
@@ -101,6 +111,7 @@ jobs:
         if: always() && steps.find-pr.outputs.pr_number
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const prNumber = ${{ steps.find-pr.outputs.pr_number }};
             const status = '${{ job.status }}';
@@ -135,6 +146,7 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
             const commitSha = '${{ github.sha }}'.substring(0, 7);

--- a/digger.yml
+++ b/digger.yml
@@ -26,6 +26,9 @@ projects:
 # Auto-merge when all checks pass
 auto_merge: false
 
+# Post-merge behavior: apply changes when merged to default branch
+on_commit_to_default: apply
+
 # Comment options
 comment_render_mode: basic
 


### PR DESCRIPTION
## Summary

Fixes the post-merge CI failures by:

1. **Using infra-flash App Token** instead of `GITHUB_TOKEN`
   - Generate token via `actions/create-github-app-token@v1`
   - Pass to Digger and all `github-script` steps

2. **Enable Digger `on_commit_to_default`**
   - Added `on_commit_to_default: apply` to `digger.yml`
   - This tells Digger to apply changes when pushed to main

### Root Cause
- Digger reported `unsupported event type` for `push` events
- `GITHUB_TOKEN` lacked `statuses:write` permission for `createCommitStatus`

### Changes
- `digger.yml`: Added `on_commit_to_default: apply`
- `ci.yml`: Generate App Token in post-merge job
- `ci.yml`: All 3 github-script steps now use App Token