### PR TITLE
Data: switch Redis/ClickHouse to operators

### DIFF
--- a/0.tools/README.md
+++ b/0.tools/README.md
@@ -53,25 +53,25 @@ Run before `terraform apply` to catch common issues early (e.g., Helm URL valida
 
 ## L3 Import Script
 
-**File**: `l3-import.sh`
+**File**: `data-import.sh`
 
 Shared script for importing existing L3 resources (namespace, Helm releases, secrets) into Terraform state. Eliminates code duplication between Atlantis CI and GitHub Actions deploy workflows.
 
 ### Usage
 ```bash
-./0.tools/l3-import.sh <namespace> [terragrunt_command]
+./0.tools/data-import.sh <namespace> [terragrunt_command]
 ```
 
 ### Examples
 ```bash
 # Atlantis (atlantis.yaml)
-./0.tools/l3-import.sh "data-staging" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
-./0.tools/l3-import.sh "data-prod" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
+./0.tools/data-import.sh "data-staging" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
+./0.tools/data-import.sh "data-prod" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
 ```
 
 ### Resources Imported
 - `kubernetes_namespace.data`
-- `helm_release.{postgresql,redis,clickhouse,arangodb_operator}`
+- `helm_release.{redis_operator,clickhouse_operator,arangodb_operator}`
 - `kubernetes_secret.arangodb_jwt`
 
 ---
@@ -87,4 +87,4 @@ CI guard that ensures READMEs are updated when code in a directory changes. Outp
 Threshold: 60% of changed directories must have corresponding README updates.
 
 ---
-*Last updated: 2025-12-23 (Added L3 Import Script and GH_ACCOUNT support)*
+*Last updated: 2025-12-24 (Updated Data import script references and resources)*

--- a/0.tools/data-import.sh
+++ b/0.tools/data-import.sh
@@ -2,11 +2,11 @@
 # Data Import Script - Shared logic for importing existing Data layer resources into Terraform state
 # Used by Atlantis (atlantis.yaml) for Data resource state synchronization
 #
-# Usage: ./0.tools/l3-import.sh <namespace> [terragrunt_command]
+# Usage: ./0.tools/data-import.sh <namespace> [terragrunt_command]
 #
 # Examples:
-#   ./0.tools/l3-import.sh "data-prod" "terragrunt"
-#   ./0.tools/l3-import.sh "data-staging" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
+#   ./0.tools/data-import.sh "data-prod" "terragrunt"
+#   ./0.tools/data-import.sh "data-staging" "TG_TF_PATH=/atlantis-data/bin/terraform1.11.0 terragrunt"
 
 set -euo pipefail
 
@@ -30,9 +30,8 @@ fi
 
 # Import helm releases if they exist but not in state
 declare -A HELM_RELEASES=(
-  ["helm_release.postgresql"]="postgresql"
-  ["helm_release.redis"]="redis"
-  ["helm_release.clickhouse"]="clickhouse"
+  ["helm_release.redis_operator"]="redis-operator"
+  ["helm_release.clickhouse_operator"]="clickhouse-operator"
   ["helm_release.arangodb_operator"]="arangodb-operator"
 )
 

--- a/docs/change_log/2025-12-24.data-db-operators.md
+++ b/docs/change_log/2025-12-24.data-db-operators.md
@@ -1,0 +1,42 @@
+# 2025-12-24: Data DB Operators for Redis and ClickHouse
+
+## Situation
+
+The Data layer still used Helm charts for Redis and ClickHouse while PostgreSQL (CNPG) and ArangoDB were already operator-managed. This created an inconsistent control plane for stateful services and made it harder to standardize lifecycle handling.
+
+## Task
+
+1. Replace Redis and ClickHouse Helm releases with operator-managed CRs.
+2. Preserve existing Vault/VSO secret flow and service DNS names for L4 apps.
+3. Update Data layer docs to reflect the operator flow.
+
+## Action
+
+### 1. Redis → Opstree Redis Operator
+
+- Installed `redis-operator` and created a standalone `Redis` CR that reads `redis-credentials` from VSO.
+- Kept service name `redis-master` to avoid changing app connection strings.
+
+### 2. ClickHouse → Altinity Operator
+
+- Installed `altinity-clickhouse-operator` and created a `ClickHouseInstallation` CR.
+- Configured default user password from `random_password` and preserved the `clickhouse` service DNS.
+- Set PVC template to `local-path-retain` for data persistence.
+
+### 3. Dependencies and Outputs
+
+- Updated health outputs, OpenPanel deps, and ClickHouse user provisioning to follow operator readiness.
+
+### 4. Documentation
+
+- Adjusted Data layer README wording from Helm to operator flow.
+
+## Result
+
+- Redis and ClickHouse are now operator-managed in the Data layer.
+- Vault/VSO secret flow and service addresses remain unchanged for L4 apps.
+- Confidence: 80% (not applied in-cluster).
+
+## Provider Priority Note
+
+- Redis uses the Opstree community operator because there is no official open-source standalone Redis operator; documented here per SOP.

--- a/docs/change_log/README.md
+++ b/docs/change_log/README.md
@@ -3,6 +3,7 @@
 Time-ordered history of completed work. Each entry is an immutable snapshot (named `YYYY-MM-DD.*.md`). `0.check_now.md` points to the active context; when a sprint/topic closes, its notes move here as a dated log.
 
 ## Recent Entries
+- [2025-12-24: Data DB Operators for Redis and ClickHouse](./2025-12-24.data-db-operators.md)
 - [2025-12-22: L1 Bootstrap Provider Migration](./2025-12-22.l1_provider_migration.md)
 - [2025-12-22: Fix Data Layer CI and Clarify SSOT Responsibilities](./2025-12-22.fix_data_ci_and_docs.md)
 - [2025-12-22: Implement Vault RBAC with Identity Groups](./2025-12-22.vault_rbac_identity_groups.md)
@@ -11,4 +12,4 @@ Time-ordered history of completed work. Each entry is an immutable snapshot (nam
 - [2025-12-15: Infra-Flash Per-Commit Implementation](./2025-12-15.infra_flash_per_commit.md)
 
 ---
-*Last updated: 2025-12-22*
+*Last updated: 2025-12-24*

--- a/envs/data-shared/1.postgres.tf
+++ b/envs/data-shared/1.postgres.tf
@@ -316,7 +316,7 @@ resource "vault_kv_secret_v2" "openpanel" {
     clickhouse_database = "openpanel_events"
   })
 
-  depends_on = [kubectl_manifest.postgresql_cluster, helm_release.redis, random_password.openpanel_clickhouse]
+  depends_on = [kubectl_manifest.postgresql_cluster, kubectl_manifest.redis, random_password.openpanel_clickhouse]
 
   lifecycle {
     # Don't overwrite existing credentials in Vault during state recovery

--- a/envs/data-shared/99.checks.tf
+++ b/envs/data-shared/99.checks.tf
@@ -7,8 +7,8 @@
 output "data_health_status" {
   value = {
     postgres   = "cnpg-cluster" # Using kubectl_manifest.postgresql_cluster
-    redis      = helm_release.redis.status
-    clickhouse = helm_release.clickhouse.status
+    redis      = helm_release.redis_operator.status
+    clickhouse = helm_release.clickhouse_operator.status
     arangodb   = helm_release.arangodb_operator.status
   }
   description = "Data services deployment status summary"

--- a/envs/prod/data/README.md
+++ b/envs/prod/data/README.md
@@ -29,7 +29,7 @@ graph LR
         RND[random_password] --> KV[Vault KV]
         KV --> |VaultStaticSecret| VSO
         VSO --> |sync| K8S[K8s Secret]
-        K8S --> |existingSecret| HELM[DB Helm Charts]
+        K8S --> |existingSecret| OP[DB Operators]
         RND --> DB_CFG[database_secret_backend]
     end
     VM --> KV
@@ -44,7 +44,7 @@ graph LR
 1. `random_password` generates password on first deploy
 2. `vault_kv_secret_v2` stores in Vault (SSOT, with `ignore_changes`)
 3. `VaultStaticSecret` CR tells VSO to sync Vault → K8s Secret
-4. Helm chart uses `existingSecret` to read from K8s Secret
+4. Operator CR uses `existingSecret` to read from K8s Secret
 5. No more fragile `data.external` + kubectl exec workarounds
 
 ### Components
@@ -61,7 +61,7 @@ graph LR
 
 1. **Bootstrap**: k3s, Platform PostgreSQL
 2. **Platform**: Vault, vault_mount, VSO (Vault Secrets Operator)
-3. **Data**: Create Vault KV → VSO syncs to K8s Secret → Helm uses existingSecret
+3. **Data**: Create Vault KV → VSO syncs to K8s Secret → Operator CR uses existingSecret
 4. **Applications**: Get dynamic credentials via Vault Agent
 
 ### Credentials
@@ -101,16 +101,16 @@ The `data-prod` namespace is **owned by Data layer**. This follows the pattern:
 
 ### VSO Pattern Rationale
 
-Password flow: `random_password` → `Vault KV` → `VSO` → `K8s Secret` → `Helm existingSecret`
+Password flow: `random_password` → `Vault KV` → `VSO` → `K8s Secret` → `Operator CR existingSecret`
 
 | Location | Purpose | Justification |
 |----------|---------|---------------|
 | Vault KV (`secret/data/postgres`) | SSOT for all credentials | Single source of truth, supports rotation |
-| K8s Secret (via VSO sync) | Helm chart consumption | Helm `existingSecret` reads from K8s Secret |
+| K8s Secret (via VSO sync) | Operator CR consumption | Operator `existingSecret` reads from K8s Secret |
 | VaultStaticSecret CR | Automation | VSO watches Vault and auto-syncs to K8s |
 
 **Why VSO instead of Vault Agent Injector?**
-- Helm charts natively support `existingSecret` parameter
+- Operator CRs natively support existing Secrets (e.g., `redisSecret`)
 - VSO provides automatic sync (no sidecar needed for databases)
 - Cleaner than `data.external` + kubectl exec workarounds
 
@@ -132,7 +132,7 @@ kubectl exec -n "$NS" postgresql-0 -- psql -U postgres -d app < l3_backup.sql
 1. **Terraform State Lost** (VSO Pattern - Issue #351):
    - Vault KV secrets protected by `ignore_changes` (won't overwrite)
    - VSO auto-syncs existing Vault secrets to K8s Secrets
-   - Helm uses `existingSecret` → no password mismatch
+   - Operator CR uses `existingSecret` → no password mismatch
    - Database continues with same credentials
 2. **Data Loss**: Restore from pg_dump backup
 3. **Full Recreation**: Delete `data-<env>` namespace, re-apply L3
@@ -167,14 +167,14 @@ lifecycle {
 - ✅ **ClickHouse**: Password validation (16+ chars)
 - ✅ **ArangoDB**: Password validation (16+ chars) + JWT secret precondition
 
-### Helm Chart Configuration
+### Operator Configuration
 
 - **Timeout**: 300s (standardized across all releases)
 - **Wait**: `wait = true` ensures readiness before completion
 - **Lifecycle**: `prevent_destroy = true` on all database releases
 - **Storage**: follow [ops.storage.md](../docs/ssot/ops.storage.md) (`local-path-retain`, reclaim policy, /data conventions)
 
-**Note**: initContainer and other Pod-level health checks are configured via Helm chart defaults, not in Terraform values per SSOT guidelines.
+**Note**: initContainer and other Pod-level health checks are configured via operator defaults, not in Terraform values per SSOT guidelines.
 Scalability for MVP:
 - **Redis**: Master-only (no replicas)
 - **ClickHouse**: Single shard, no ZooKeeper


### PR DESCRIPTION
## Summary
- replace Redis Helm chart with Opstree redis-operator + Redis CR (keep redis-master DNS)
- replace ClickHouse Helm chart with Altinity operator + ClickHouseInstallation CR (keep clickhouse DNS)
- update OpenPanel deps/health outputs, data import script, and data layer READMEs

## Testing
- terraform fmt -check envs/data-shared

## Notes
- Operator migration will recreate Redis/ClickHouse resources; plan/apply should consider data migration/backup.