### PR TITLE
fix(ci): fix SSH key formatting and bootstrap deploy script injection

### DIFF
--- a/.github/workflows/bootstrap-deploy.yml
+++ b/.github/workflows/bootstrap-deploy.yml
@@ -56,8 +56,10 @@ jobs:
     steps:
       - name: Parse Command
         id: parse
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if [[ "${{ github.event.comment.body }}" == *"/bootstrap apply"* ]]; then
+          if [[ "$COMMENT_BODY" == *"/bootstrap apply"* ]]; then
             echo "action=apply" >> $GITHUB_OUTPUT
           else
             echo "action=plan" >> $GITHUB_OUTPUT

--- a/0.tools/ci_load_secrets.py
+++ b/0.tools/ci_load_secrets.py
@@ -76,8 +76,13 @@ REQUIRED = [
 def clean_value(val):
     if val is None: return None
     s = str(val).strip()
-    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'" ) and s.endswith("'")):
+    if (s.startswith('"') and s.endswith('"')) or (s.startswith("'") and s.endswith("'")):
         s = s[1:-1].strip()
+    
+    # Critical: SSH keys MUST end with a newline for libcrypto/OpenSSL
+    if "PRIVATE KEY-----" in s and not s.endswith("\n"):
+        s += "\n"
+        
     return s
 
 def export_to_github_env(name, value):


### PR DESCRIPTION
## Critical Fixes for Bootstrap CI

### 1. SSH Key Formatting (Fixes #395 Regression)
- **Problem**: `ci_load_secrets.py` was stripping trailing newlines from secrets. OpenSSL/libcrypto requires private keys to end with a newline.
- **Symptom**: `Load key ...: error in libcrypto` in Bootstrap Deploy job.
- **Fix**: Modified `clean_value` to append newline to private keys if missing.

### 2. Script Injection (Security)
- **Problem**: `bootstrap-deploy.yml` used direct interpolation of comment body (`${{ github.event.comment.body }}`) in bash script.
- **Fix**: Moved to `env` variable `COMMENT_BODY`.