### PR TITLE
fix: CI workflow syntax and slash command dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/check'))
+       (contains(github.event.comment.body, '/check') ||
+        contains(github.event.comment.body, '/bootstrap-apply') ||
+        contains(github.event.comment.body, '/apply')))
     runs-on: ubuntu-latest
     steps:
       - name: Comment Start (/check)
@@ -140,7 +142,8 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/bootstrap-plan'))
+       (contains(github.event.comment.body, '/bootstrap-plan') ||
+        contains(github.event.comment.body, '/bootstrap-apply')))
     needs: [check]
     runs-on: ubuntu-latest
     steps:
@@ -344,9 +347,8 @@ jobs:
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/bootstrap-apply'))
-    # On push: depends on check, bootstrap-plan
-    # On comment: run independently (no dependencies to avoid skip cascade)
-    needs: ${{ github.event_name == 'push' && fromJSON('["check", "bootstrap-plan"]') || fromJSON('[]') }}
+    # Always run after check and bootstrap-plan complete (success or skipped)
+    needs: [check, bootstrap-plan]
     runs-on: ubuntu-latest
     steps:
       - name: Comment Start (/bootstrap-apply)


### PR DESCRIPTION
## Problem

The previous commit introduced invalid `needs` syntax:
```yaml
needs: ${{ github.event_name == 'push' && fromJSON('...') || fromJSON('[]') }}
```
GitHub Actions doesn't support conditional `needs` expressions, causing all workflows to fail.

## Solution

1. **Revert to static `needs`** - Keep simple dependency chain
2. **Expand job triggers** - Make `check` and `bootstrap-plan` also run when:
   - `/bootstrap-apply` is called
   - `/apply` is called

This ensures dependencies are satisfied before apply jobs run.

## Changes

- `check` now triggers on `/bootstrap-apply` and `/apply` comments
- `bootstrap-plan` now triggers on `/bootstrap-apply` comments
- Fixed `bootstrap-apply` to use static `needs: [check, bootstrap-plan]`

## Testing

After merge:
1. Comment `/bootstrap-apply` on a PR
2. Should see: check → bootstrap-plan → bootstrap-apply all run